### PR TITLE
fix: Add identifier to verification requests

### DIFF
--- a/packages/fauna/README.md
+++ b/packages/fauna/README.md
@@ -32,6 +32,9 @@ CreateIndex({
   name: 'verification_request_by_token',
   source: Collection('verification_requests'),
   unique: true,
-  terms: [{ field: ['data', 'token'] }],
+  terms: [
+    { field: ['data', 'token'] }, 
+    { field: ['data', 'identifier'] }
+  ],
 })
 ```

--- a/packages/fauna/src/index.js
+++ b/packages/fauna/src/index.js
@@ -448,7 +448,10 @@ const Adapter = (config, options = {}) => {
         .digest('hex')
       const FQL = q.Let(
         {
-          ref: q.Match(q.Index(indexes.VerificationRequest), hashedToken),
+          ref: q.Match(q.Index(indexes.VerificationRequest), [
+            hashedToken,
+            identifier,
+          ]),
         },
         q.If(
           q.Exists(q.Var('ref')),
@@ -498,7 +501,12 @@ const Adapter = (config, options = {}) => {
       const FQL = q.Delete(
         q.Select(
           'ref',
-          q.Get(q.Match(q.Index(indexes.VerificationRequest), hashedToken))
+          q.Get(
+            q.Match(q.Index(indexes.VerificationRequest), [
+              hashedToken,
+              identifier,
+            ])
+          )
         )
       )
 


### PR DESCRIPTION
CC: @balazsorban44 

This PR includes the `identifier` in the Fauna query for `getVerificationRequest` and `deleteVerificationRequest`. This prevents a valid token being used in combination with any identifier other than the one for which the request was issued.

Also change the documentation to reflect the necessary change to the `verification_request_by_token` index to include the identifier. 

This should be treated as a breaking change since an update to a Fauna index is required, which required manual intervention.
