### PR TITLE
fix(prisma): populating `sessionCache` in `createSession`

### DIFF
--- a/packages/prisma/src/index.ts
+++ b/packages/prisma/src/index.ts
@@ -270,22 +270,14 @@ export default function PrismaAdapter<
         expires = dateExpires.toISOString();
 
         const session = {
+          userId: user.id,
           expires,
           sessionToken: randomBytes(32).toString("hex"),
           accessToken: randomBytes(32).toString("hex"),
-          userId: user.id,
         };
 
         sessionCache.set(session.sessionToken, session, maxAge(expires));
-
-        return prisma[Session as "session"].create({
-          data: {
-            expires,
-            user: { connect: { id: user.id } },
-            sessionToken: randomBytes(32).toString("hex"),
-            accessToken: randomBytes(32).toString("hex"),
-          },
-        });
+        return prisma[Session as "session"].create({ data: session });
       } catch (error) {
         logger.error("CREATE_SESSION_ERROR", error);
         // @ts-ignore

--- a/packages/prisma/src/index.ts
+++ b/packages/prisma/src/index.ts
@@ -1,7 +1,6 @@
 import * as Prisma from "@prisma/client";
 import { Session, User } from "@prisma/client";
 import { createHash, randomBytes } from "crypto";
-import { klona } from "klona";
 import LRU from "lru-cache";
 import { AppOptions } from "next-auth";
 import { EmailSessionProvider, Profile } from "next-auth/adapters";
@@ -274,12 +273,10 @@ export default function PrismaAdapter<
           expires,
           sessionToken: randomBytes(32).toString("hex"),
           accessToken: randomBytes(32).toString("hex"),
-          user,
+          userId: user.id,
         };
 
-        const cachedSession = klona(session);
-
-        sessionCache.set(session.sessionToken, cachedSession, maxAge(expires));
+        sessionCache.set(session.sessionToken, session, maxAge(expires));
 
         return prisma[Session as "session"].create({
           data: {


### PR DESCRIPTION
According to the current implementation of NextAuth, `session` objects must have a `userId` property instead of a `user` with an `id`:

https://github.com/nextauthjs/next-auth/blob/34f334a71d9693ed177168dbc4bf706b2734f8ff/src/server/routes/session.js#L68

The [`/session` route](https://github.com/nextauthjs/next-auth/blob/main/src/server/routes/session.js) of NextAuth only takes the following properties into account on a session object:

- `userId`
- `accessToken`
- `expires`

Also, users are retrieved from the `userCache` when the following line is executed by NextAuth – so this change shouldn’t affect caching performance:

```ts
const user = await getUser(session.userId)
```