### PR TITLE
refactor(prisma): loosen `peerDependencies` ranges

### DIFF
--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -31,8 +31,8 @@
     "dist"
   ],
   "peerDependencies": {
-    "@prisma/client": "^2.15.0",
-    "next-auth": "^3.1.0"
+    "@prisma/client": ">=2.15.0",
+    "next-auth": ">=3.1.0"
   },
   "dependencies": {
     "crypto": "^1.0.1",


### PR DESCRIPTION
This change is to ensure better compliance with npm v7’s new peer dependency resolution algorithm.