### PR TITLE
docs(prisma): add missing multicolumn unique index to the schema

### DIFF
--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -47,6 +47,8 @@ model VerificationRequest {
   expires    DateTime
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
+
+  @@unique([identifier, token])
 }
 
 ```
@@ -134,5 +136,6 @@ Changes from the original Prisma Adapter
 +  updatedAt  DateTime @updatedAt
 
 -  @@map(name: "verification_requests")
++  @@unique([identifier, token])
  }
 ```


### PR DESCRIPTION
`identifier_token` – a multicolumn unique index – is required by the implementation. Please see the operations referencing it below:

https://github.com/nextauthjs/adapters/blob/892c4f760cebe48c73447715d41fab4ef14ec71e/packages/prisma/src/index.ts#L471-L480

https://github.com/nextauthjs/adapters/blob/892c4f760cebe48c73447715d41fab4ef14ec71e/packages/prisma/src/index.ts#L487-L494

https://github.com/nextauthjs/adapters/blob/892c4f760cebe48c73447715d41fab4ef14ec71e/packages/prisma/src/index.ts#L518-L525