### PR TITLE
docs(adapters): update links to match docs page update

### DIFF
--- a/packages/dynamodb/README.md
+++ b/packages/dynamodb/README.md
@@ -18,7 +18,7 @@ This is the AWS DynamoDB Adapter for next-auth. This package can only be used in
 
 You need a table with a partition key `pk` and a sort key `sk`. Your table also needs a global secondary index named `GSI1` with `GSI1PK` as partition key and `GSI1SK` as sorting key. You can set whatever you want as the table name and the billing method.
 
-You can find the full schema in the table structure section below.
+You can find the DynamoDB schema in the docs at [next-auth.js.org/adapters/dynamodb](https://next-auth.js.org/adapters/dynamodb).
 
 ## Getting Started
 

--- a/packages/fauna/README.md
+++ b/packages/fauna/README.md
@@ -17,7 +17,7 @@
 
 This is the Fauna Adapter for [`next-auth`](https://next-auth.js.org). This package can only be used in conjunction with the primary `next-auth` package. It is not a standalone package.
 
-You can find the Fauna schema and seed information in the docs at [next-auth.js.org/schemas/fauna](https://next-auth.js.org/schemas/fauna).
+You can find the Fauna schema and seed information in the docs at [next-auth.js.org/adapters/fauna](https://next-auth.js.org/adapters/fauna).
 
 ## Getting Started
 

--- a/packages/firebase/README.md
+++ b/packages/firebase/README.md
@@ -17,6 +17,8 @@
 
 This is the Firebase Adapter for [`next-auth`](https://next-auth.js.org). This package can only be used in conjunction with the primary `next-auth` package. It is not a standalone package.
 
+You can find more Firebase information in the docs at [next-auth.js.org/adapters/firebase](https://next-auth.js.org/adapters/firebase).
+
 ## Getting Started
 
 1. Install `next-auth` and `@next-auth/firebase-adapter`

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -16,7 +16,7 @@
 
 This is the Prisma Adapter for [`next-auth`](https://next-auth.js.org). This package can only be used in conjunction with the primary `next-auth` package. It is not a standalone package.
 
-You can find the Prisma schema in the docs at [next-auth.js.org/schemas/prisma](https://next-auth.js.org/schemas/prisma).
+You can find the Prisma schema in the docs at [next-auth.js.org/adapters/prisma](https://next-auth.js.org/adapters/prisma).
 
 ## Getting Started
 

--- a/packages/typeorm-legacy/README.md
+++ b/packages/typeorm-legacy/README.md
@@ -16,6 +16,8 @@
 
 This is the TypeORM Adapter for [`next-auth`](https://next-auth.js.org). This package can only be used in conjunction with the primary `next-auth` package. It is not a standalone package.
 
+You can find more TypeORM information in the docs at [next-auth.js.org/adapters/typeorm/typeorm-overview](https://next-auth.js.org/adapters/typeorm/typeorm-overview).
+
 ## Getting Started
 
 1. Install `next-auth` and `@next-auth/typeorm-legacy-adapter`


### PR DESCRIPTION
Updates links (and adds a link to the docs in the adapters that were missing a link to the docs) based on the new `/adapters` URLs, isntead of `/schema` docs URLs we had based upon next-auth docs PR https://github.com/nextauthjs/next-auth/pull/2051