### PR TITLE
chore(repo): add pr labeler gh-action + stale.yml + pr_template.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,51 @@
+<!--
+Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!
+
+Please make sure that you are familiar with and follow the Code of Conduct for
+this project (found in the CODE_OF_CONDUCT.md file).
+
+Also, please make sure you're familiar with and follow the instructions in the
+contributing guidelines (found in the CONTRIBUTING.md file).
+
+If you're new to contributing to open source projects, you might find this free
+video course helpful: https://kcd.im/pull-request
+
+Please fill out the information below to expedite the review and (hopefully)
+merge of your pull request!
+-->
+
+## Reasoning 💡
+
+<!--
+What changes are being made? What feature/bug is being fixed here?
+
+IMPORTANT: Which, if any, adapter is being affected? Or are you wanting to add
+a new one?
+ -->
+
+## Checklist 🧢
+
+<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.
+
+To check an item, place an `x` in the box like so: `- [x] Documentation`. -->
+
+- [ ] Documentation
+- [ ] Tests
+- [ ] Ready to be merged
+
+<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
+
+## Affected issues 🎟
+
+<!--
+Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.
+
+If you write `"Fixes"` or `"Closes"` before the issue link like so:
+
+```
+Fixes #359
+```
+
+the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊
+
+-->

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,22 @@
+fauna:
+  - packages/fauna/**/*
+
+dynamodb:
+  - packages/dynamodb/**/*
+
+prisma:
+  - packages/prisma/**/*
+  - packages/prisma-legacy/**/*
+
+typeorm:
+  - packages/typeorm-legacy/**/*
+
+firebase:
+  - packages/firebase/**/*
+
+documentation:
+  - ./**/*.md
+
+tests:
+  - jest.config.js
+  - packages/**/tests/*

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,25 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 14
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+  - priority
+  - bug
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  Hi there! It looks like this issue hasn't had any activity for a while.
+  It will be closed if no further activity occurs. If you think your issue
+  is still relevant, feel free to comment on it to keep it open.
+  Thanks!
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  Hi there! It looks like this issue hasn't had any activity for a while.
+  To keep things tidy, I am going to close this issue for now.
+  If you think your issue is still relevant, just leave a comment
+  and I will reopen it.
+  Thanks!

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: "${{ secrets.GH_PAT }}"


### PR DESCRIPTION
Added [`labeler`](https://github.com/actions/labeler) gh-action to automatically label PRs.

Also added `stale.yml` to automatically comment and then close stale issues. I increased the time limits for this repo compared to the core repo a bit.

Also added the PR_TEMPLATE file, which I basically copied 1:1 from the core repo, and added a little info about "mention which adapter this PR is pertaining to, if any".