### PR TITLE
feat(dynamodb): use new Adapter API

### DIFF
--- a/packages/dynamodb/package.json
+++ b/packages/dynamodb/package.json
@@ -30,7 +30,7 @@
   "license": "ISC",
   "peerDependencies": {
     "dynamodb": "^1.3.0",
-    "next-auth": "^3.17.2"
+    "next-auth": "^>=4"
   },
   "devDependencies": {
     "@types/dynamodb": "^1.2.2",

--- a/packages/dynamodb/package.json
+++ b/packages/dynamodb/package.json
@@ -19,7 +19,9 @@
     "access": "public"
   },
   "scripts": {
-    "test": "echo \"Fix tests.\";exit 0",
+    "test:default": "jest",
+    "test:custom": "CUSTOM_MODEL=1 jest",
+    "test": "yarn test:default",
     "build": "tsc"
   },
   "files": [
@@ -30,7 +32,7 @@
   "license": "ISC",
   "peerDependencies": {
     "dynamodb": "^1.3.0",
-    "next-auth": "^>=4"
+    "next-auth": "^4.0.0"
   },
   "devDependencies": {
     "@types/dynamodb": "^1.2.2",

--- a/packages/dynamodb/src/index.ts
+++ b/packages/dynamodb/src/index.ts
@@ -10,7 +10,6 @@ export function DynamoDBAdapter(
   return {
     async createUser(profile: any) {
       const userId = randomBytes(16).toString("hex")
-      const now = new Date()
       const item: any = {
         pk: `USER#${userId}`,
         sk: `USER#${userId}`,
@@ -21,8 +20,6 @@ export function DynamoDBAdapter(
         image: profile.image,
         username: profile.username,
         emailVerified: profile.emailVerified?.toISOString() ?? null,
-        createdAt: now.toISOString(),
-        updatedAt: now.toISOString(),
       }
 
       if (profile.email) {
@@ -140,8 +137,6 @@ export function DynamoDBAdapter(
       return deleted
     },
     async linkAccount(data) {
-      const now = new Date()
-
       const item = {
         pk: `USER#${data.userId}`,
         sk: `ACCOUNT#${data.provider}#${data.providerAccountId}`,
@@ -160,8 +155,6 @@ export function DynamoDBAdapter(
         tokenType: data.token_type,
         scope: data.scope,
         sessionState: data.session_state,
-        createdAt: now.toISOString(),
-        updatedAt: now.toISOString(),
       }
 
       await client.put({ TableName, Item: item }).promise()
@@ -236,8 +229,6 @@ export function DynamoDBAdapter(
       return { user, session }
     },
     async createSession({ sessionToken, userId, expires }) {
-      const now = new Date()
-
       const item = {
         pk: `USER#${userId}`,
         sk: `SESSION#${sessionToken}`,
@@ -247,8 +238,6 @@ export function DynamoDBAdapter(
         type: "SESSION",
         userId,
         expires: expires.toISOString(),
-        createdAt: now.toISOString(),
-        updatedAt: now.toISOString(),
       }
 
       await client.put({ TableName, Item: item }).promise()
@@ -280,14 +269,12 @@ export function DynamoDBAdapter(
             pk: session.pk,
             sk: session.sk,
           },
-          UpdateExpression: "set #expires = :expires, #updatedAt = :updatedAt",
+          UpdateExpression: "set #expires = :expires",
           ExpressionAttributeNames: {
             "#expires": "expires",
-            "#updatedAt": "updatedAt",
           },
           ExpressionAttributeValues: {
             ":expires": (expires as Date).toISOString(),
-            ":updatedAt": new Date().toISOString(),
           },
           ReturnValues: "UPDATED_NEW",
         })
@@ -327,8 +314,6 @@ export function DynamoDBAdapter(
       return deleted
     },
     async createVerificationToken({ identifier, expires, token }) {
-      const now = new Date()
-
       const item = {
         pk: `VR#${identifier}`,
         sk: `VR#${token}`,
@@ -336,8 +321,6 @@ export function DynamoDBAdapter(
         identifier,
         type: "VR",
         expires: expires.toISOString(),
-        createdAt: now.toISOString(),
-        updatedAt: now.toISOString(),
       }
 
       await client.put({ TableName, Item: item }).promise()

--- a/packages/dynamodb/src/index.ts
+++ b/packages/dynamodb/src/index.ts
@@ -1,447 +1,346 @@
-import { createHash, randomBytes } from "crypto"
-import { Profile, Session, User } from "next-auth"
-import { Adapter } from "next-auth/adapters"
+import { randomBytes } from "crypto"
+import type { Adapter } from "next-auth/adapters"
 
-export const DynamoDBAdapter: Adapter<
-  any,
-  {
-    tableName: string
-  },
-  User & { emailVerified?: Date },
-  Profile & { emailVerified?: Date },
-  Session
-> = (client, options) => {
+export function DynamoDBAdapter(
+  client: any,
+  options?: { tableName: string }
+): Adapter {
   const TableName = options?.tableName ?? "next-auth"
 
   return {
-    async getAdapter({ logger, session, secret, ...appOptions }) {
-      const sessionMaxAge = session.maxAge * 1000 // default is 30 days
-      const sessionUpdateAge = session.updateAge * 1000 // default is 1 day
+    async createUser(profile: any) {
+      const userId = randomBytes(16).toString("hex")
+      const now = new Date()
+      const item: any = {
+        pk: `USER#${userId}`,
+        sk: `USER#${userId}`,
+        id: userId,
+        type: "USER",
+        name: profile.name,
+        email: profile.email,
+        image: profile.image,
+        username: profile.username,
+        emailVerified: profile.emailVerified?.toISOString() ?? null,
+        createdAt: now.toISOString(),
+        updatedAt: now.toISOString(),
+      }
 
-      /**
-       * @todo Move this to core package
-       * @todo Use bcrypt or a more secure method
-       */
-      const hashToken = (token: string) =>
-        createHash("sha256").update(`${token}${secret}`).digest("hex")
+      if (profile.email) {
+        item.GSI1SK = `USER#${profile.email as string}`
+        item.GSI1PK = `USER#${profile.email as string}`
+      }
 
-      return {
-        displayName: "DYNAMODB",
-        async createUser(profile) {
-          const userId = randomBytes(16).toString("hex")
-          const now = new Date()
-          const item: any = {
+      await client.put({ TableName, Item: item }).promise()
+      return item
+    },
+    async getUser(userId) {
+      const data = await client
+        .get({
+          TableName,
+          Key: {
             pk: `USER#${userId}`,
             sk: `USER#${userId}`,
-            id: userId,
-            type: "USER",
-            name: profile.name,
-            email: profile.email,
-            image: profile.image,
-            username: profile.username,
-            emailVerified: profile.emailVerified?.toISOString() ?? null,
-            createdAt: now.toISOString(),
-            updatedAt: now.toISOString(),
-          }
+          },
+        })
+        .promise()
 
-          if (profile.email) {
-            item.GSI1SK = `USER#${profile.email}`
-            item.GSI1PK = `USER#${profile.email}`
-          }
+      return data.Item || null
+    },
+    async getUserByEmail(email) {
+      const data = await client
+        .query({
+          TableName,
+          IndexName: "GSI1",
+          KeyConditionExpression: "#gsi1pk = :gsi1pk AND #gsi1sk = :gsi1sk",
+          ExpressionAttributeNames: {
+            "#gsi1pk": "GSI1PK",
+            "#gsi1sk": "GSI1SK",
+          },
+          ExpressionAttributeValues: {
+            ":gsi1pk": `USER#${email ?? ""}`,
+            ":gsi1sk": `USER#${email ?? ""}`,
+          },
+        })
+        .promise()
 
-          await client.put({ TableName, Item: item }).promise()
-          return item
-        },
-        async getUser(id) {
-          const data = await client
-            .get({
-              TableName,
-              Key: {
-                pk: `USER#${id}`,
-                sk: `USER#${id}`,
-              },
-            })
-            .promise()
+      return data.Items[0] || null
+    },
+    async getUserByAccount({ provider, providerAccountId }) {
+      const data = await client
+        .query({
+          TableName,
+          IndexName: "GSI1",
+          KeyConditionExpression: "#gsi1pk = :gsi1pk AND #gsi1sk = :gsi1sk",
+          ExpressionAttributeNames: {
+            "#gsi1pk": "GSI1PK",
+            "#gsi1sk": "GSI1SK",
+          },
+          ExpressionAttributeValues: {
+            ":gsi1pk": `ACCOUNT#${provider}`,
+            ":gsi1sk": `ACCOUNT#${providerAccountId}`,
+          },
+        })
+        .promise()
 
-          return data.Item || null
-        },
-        async getUserByEmail(email) {
-          const data = await client
-            .query({
-              TableName,
-              IndexName: "GSI1",
-              KeyConditionExpression: "#gsi1pk = :gsi1pk AND #gsi1sk = :gsi1sk",
-              ExpressionAttributeNames: {
-                "#gsi1pk": "GSI1PK",
-                "#gsi1sk": "GSI1SK",
-              },
-              ExpressionAttributeValues: {
-                ":gsi1pk": `USER#${email ?? ""}`,
-                ":gsi1sk": `USER#${email ?? ""}`,
-              },
-            })
-            .promise()
+      if (!data || !data.Items.length) return null
 
-          return data.Items[0] || null
-        },
-        async getUserByProviderAccountId(providerId, providerAccountId) {
-          const data = await client
-            .query({
-              TableName,
-              IndexName: "GSI1",
-              KeyConditionExpression: "#gsi1pk = :gsi1pk AND #gsi1sk = :gsi1sk",
-              ExpressionAttributeNames: {
-                "#gsi1pk": "GSI1PK",
-                "#gsi1sk": "GSI1SK",
-              },
-              ExpressionAttributeValues: {
-                ":gsi1pk": `ACCOUNT#${providerAccountId}`,
-                ":gsi1sk": `ACCOUNT#${providerId}`,
-              },
-            })
-            .promise()
+      const user = await client
+        .get({
+          TableName,
+          Key: {
+            pk: `USER#${data.Items[0].userId as string}`,
+            sk: `USER#${data.Items[0].userId as string}`,
+          },
+        })
+        .promise()
 
-          if (!data || !data.Items.length) return null
+      return user.Item || null
+    },
+    async updateUser(user) {
+      const now = new Date()
+      const data = await client
+        .update({
+          TableName,
+          Key: {
+            pk: user.pk,
+            sk: user.sk,
+          },
+          UpdateExpression:
+            "set #name = :name, #email = :email, #gsi1pk = :gsi1pk, #gsi1sk = :gsi1sk, #image = :image, #emailVerified = :emailVerified, #username = :username, #updatedAt = :updatedAt",
+          ExpressionAttributeNames: {
+            "#name": "name",
+            "#email": "email",
+            "#gsi1pk": "GSI1PK",
+            "#gsi1sk": "GSI1SK",
+            "#image": "image",
+            "#emailVerified": "emailVerified",
+            "#username": "username",
+            "#updatedAt": "updatedAt",
+          },
+          ExpressionAttributeValues: {
+            ":name": user.name,
+            ":email": user.email,
+            ":gsi1pk": `USER#${user.email as string}`,
+            ":gsi1sk": `USER#${user.email as string}`,
+            ":image": user.image,
+            ":emailVerified": user.emailVerified?.toISOString() ?? null,
+            ":username": user.username,
+            ":updatedAt": now.toISOString(),
+          },
+          ReturnValues: "UPDATED_NEW",
+        })
+        .promise()
 
-          const user = await client
-            .get({
-              TableName,
-              Key: {
-                pk: `USER#${data.Items[0].userId as string}`,
-                sk: `USER#${data.Items[0].userId as string}`,
-              },
-            })
-            .promise()
-
-          return user.Item || null
-        },
-        async updateUser(user) {
-          const now = new Date()
-          const data = await client
-            .update({
-              TableName,
-              Key: {
-                pk: user.pk,
-                sk: user.sk,
-              },
-              UpdateExpression:
-                "set #name = :name, #email = :email, #gsi1pk = :gsi1pk, #gsi1sk = :gsi1sk, #image = :image, #emailVerified = :emailVerified, #username = :username, #updatedAt = :updatedAt",
-              ExpressionAttributeNames: {
-                "#name": "name",
-                "#email": "email",
-                "#gsi1pk": "GSI1PK",
-                "#gsi1sk": "GSI1SK",
-                "#image": "image",
-                "#emailVerified": "emailVerified",
-                "#username": "username",
-                "#updatedAt": "updatedAt",
-              },
-              ExpressionAttributeValues: {
-                ":name": user.name,
-                ":email": user.email,
-                ":gsi1pk": `USER#${user.email as string}`,
-                ":gsi1sk": `USER#${user.email as string}`,
-                ":image": user.image,
-                ":emailVerified": user.emailVerified?.toISOString() ?? null,
-                ":username": user.username,
-                ":updatedAt": now.toISOString(),
-              },
-              ReturnValues: "UPDATED_NEW",
-            })
-            .promise()
-
-          return { ...user, ...data.Attributes }
-        },
-        async deleteUser(userId) {
-          const deleted = await client
-            .delete({
-              TableName,
-              Key: {
-                pk: `USER#${userId}`,
-                sk: `USER#${userId}`,
-              },
-            })
-            .promise()
-
-          return deleted
-        },
-        async linkAccount(
-          userId,
-          providerId,
-          providerType,
-          providerAccountId,
-          refreshToken,
-          accessToken,
-          accessTokenExpires
-        ) {
-          const now = new Date()
-
-          const item = {
+      return { ...user, ...data.Attributes }
+    },
+    async deleteUser(userId) {
+      const deleted = await client
+        .delete({
+          TableName,
+          Key: {
             pk: `USER#${userId}`,
-            sk: `ACCOUNT#${providerId}#${providerAccountId}`,
-            GSI1SK: `ACCOUNT#${providerId}`,
-            GSI1PK: `ACCOUNT#${providerAccountId}`,
-            providerId,
-            providerAccountId,
-            providerType,
-            refreshToken,
-            accessToken,
-            accessTokenExpires,
-            type: "ACCOUNT",
-            userId,
-            createdAt: now.toISOString(),
-            updatedAt: now.toISOString(),
-          }
+            sk: `USER#${userId}`,
+          },
+        })
+        .promise()
 
-          await client.put({ TableName, Item: item }).promise()
-          return item as any
-        },
-        async unlinkAccount(userId, providerId, providerAccountId) {
-          const deleted = await client
-            .delete({
-              TableName,
-              Key: {
-                pk: `USER#${userId}`,
-                sk: `ACCOUNT#${providerId}#${providerAccountId}`,
-              },
-            })
-            .promise()
+      return deleted
+    },
+    async linkAccount(data) {
+      const now = new Date()
 
-          return deleted
-        },
-        async createSession(user) {
-          let expires = null
-          if (sessionMaxAge) {
-            const dateExpires = new Date()
-            dateExpires.setTime(dateExpires.getTime() + sessionMaxAge)
-            expires = dateExpires.toISOString()
-          }
-
-          const sessionToken = randomBytes(32).toString("hex")
-          const accessToken = randomBytes(32).toString("hex")
-
-          const now = new Date()
-
-          const item = {
-            pk: `USER#${user.id as string}`,
-            sk: `SESSION#${sessionToken}`,
-            GSI1SK: `SESSION#${sessionToken}`,
-            GSI1PK: `SESSION#${sessionToken}`,
-            sessionToken,
-            accessToken,
-            type: "SESSION",
-            userId: user.id,
-            expires,
-            createdAt: now.toISOString(),
-            updatedAt: now.toISOString(),
-          }
-
-          await client.put({ TableName, Item: item }).promise()
-          return item as any
-        },
-        async getSession(sessionToken) {
-          const data = await client
-            .query({
-              TableName,
-              IndexName: "GSI1",
-              KeyConditionExpression: "#gsi1pk = :gsi1pk AND #gsi1sk = :gsi1sk",
-              ExpressionAttributeNames: {
-                "#gsi1pk": "GSI1PK",
-                "#gsi1sk": "GSI1SK",
-              },
-              ExpressionAttributeValues: {
-                ":gsi1pk": `SESSION#${sessionToken}`,
-                ":gsi1sk": `SESSION#${sessionToken}`,
-              },
-            })
-            .promise()
-
-          const session = data.Items[0] || null
-
-          if (session?.expires && new Date() > session.expires) {
-            return null
-          }
-
-          return session
-        },
-        async updateSession(session, force) {
-          const shouldUpdate =
-            sessionMaxAge &&
-            (sessionUpdateAge || sessionUpdateAge === 0) &&
-            session.expires
-          if (!shouldUpdate && !force) {
-            return null
-          }
-
-          // Calculate last updated date, to throttle write updates to database
-          // Formula: ({expiry date} - sessionMaxAge) + sessionUpdateAge
-          //     e.g. ({expiry date} - 30 days) + 1 hour
-          //
-          // Default for sessionMaxAge is 30 days.
-          // Default for sessionUpdateAge is 1 hour.
-
-          // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
-          // @ts-ignore
-          const dateSessionIsDueToBeUpdated = new Date(session.expires)
-          dateSessionIsDueToBeUpdated.setTime(
-            dateSessionIsDueToBeUpdated.getTime() - sessionMaxAge
-          )
-          dateSessionIsDueToBeUpdated.setTime(
-            dateSessionIsDueToBeUpdated.getTime() + sessionUpdateAge
-          )
-
-          // Trigger update of session expiry date and write to database, only
-          // if the session was last updated more than {sessionUpdateAge} ago
-          const currentDate = new Date()
-          if (currentDate < dateSessionIsDueToBeUpdated && !force) {
-            return null
-          }
-
-          const newExpiryDate = new Date()
-          newExpiryDate.setTime(newExpiryDate.getTime() + sessionMaxAge)
-
-          const data = await client
-            .update({
-              TableName,
-              Key: {
-                pk: session.pk,
-                sk: session.sk,
-              },
-              UpdateExpression:
-                "set #expires = :expires, #updatedAt = :updatedAt",
-              ExpressionAttributeNames: {
-                "#expires": "expires",
-                "#updatedAt": "updatedAt",
-              },
-              ExpressionAttributeValues: {
-                ":expires": newExpiryDate.toISOString(),
-                ":updatedAt": new Date().toISOString(),
-              },
-              ReturnValues: "UPDATED_NEW",
-            })
-            .promise()
-
-          return {
-            ...session,
-            expires: data.Attributes.expires,
-            updatedAt: data.Attributes.updatedAt,
-          }
-        },
-        async deleteSession(sessionToken) {
-          const data = await client
-            .query({
-              TableName,
-              IndexName: "GSI1",
-              KeyConditionExpression: "#gsi1pk = :gsi1pk AND #gsi1sk = :gsi1sk",
-              ExpressionAttributeNames: {
-                "#gsi1pk": "GSI1PK",
-                "#gsi1sk": "GSI1SK",
-              },
-              ExpressionAttributeValues: {
-                ":gsi1pk": `SESSION#${sessionToken}`,
-                ":gsi1sk": `SESSION#${sessionToken}`,
-              },
-            })
-            .promise()
-
-          if (data?.Items?.length <= 0) return null
-
-          const infoToDelete = data.Items[0]
-
-          const deleted = await client
-            .delete({
-              TableName,
-              Key: {
-                pk: infoToDelete.pk,
-                sk: infoToDelete.sk,
-              },
-            })
-            .promise()
-
-          return deleted
-        },
-        async createVerificationRequest(identifier, url, token, _, provider) {
-          const { baseUrl } = appOptions
-          const { sendVerificationRequest, maxAge } = provider
-
-          const hashedToken = hashToken(token)
-
-          let expires = null
-          if (maxAge) {
-            const dateExpires = new Date()
-            dateExpires.setTime(dateExpires.getTime() + maxAge * 1000)
-
-            expires = dateExpires.toISOString()
-          }
-
-          const now = new Date()
-
-          const item = {
-            pk: `VR#${identifier}`,
-            sk: `VR#${hashedToken}`,
-            token: hashedToken,
-            identifier,
-            type: "VR",
-            expires: expires === null ? null : expires,
-            createdAt: now.toISOString(),
-            updatedAt: now.toISOString(),
-          }
-
-          await client.put({ TableName, Item: item }).promise()
-
-          await sendVerificationRequest({
-            identifier,
-            url,
-            token,
-            baseUrl,
-            provider,
-          })
-
-          return item as any
-        },
-        async getVerificationRequest(identifier, token) {
-          const hashedToken = hashToken(token)
-
-          const data = await client
-            .get({
-              TableName,
-              Key: {
-                pk: `VR#${identifier}`,
-                sk: `VR#${hashedToken}`,
-              },
-            })
-            .promise()
-
-          if (data.Item?.expires && data.Item.expires < Date.now()) {
-            // Delete the expired request so it cannot be used
-            await client
-              .delete({
-                TableName,
-                Key: {
-                  pk: `VR#${identifier}`,
-                  sk: `VR#${hashedToken}`,
-                },
-              })
-              .promise()
-
-            return null
-          }
-
-          return data.Item || null
-        },
-        async deleteVerificationRequest(identifier, token) {
-          // eslint-disable-next-line @typescript-eslint/return-await
-          return await client
-            .delete({
-              TableName,
-              Key: {
-                pk: `VR#${identifier}`,
-                sk: `VR#${hashToken(token)}`,
-              },
-            })
-            .promise()
-        },
+      const item = {
+        pk: `USER#${data.userId}`,
+        sk: `ACCOUNT#${data.provider}#${data.providerAccountId}`,
+        GSI1SK: `ACCOUNT#${data.provider}`,
+        GSI1PK: `ACCOUNT#${data.providerAccountId}`,
+        provider: data.provider,
+        providerAccountId: data.providerAccountId,
+        providerType: data.providerType,
+        refreshToken: data.refreshToken,
+        accessToken: data.accessToken,
+        accessTokenExpires: data.accessTokenExpires,
+        type: "ACCOUNT",
+        userId: data.userId,
+        createdAt: now.toISOString(),
+        updatedAt: now.toISOString(),
       }
+
+      await client.put({ TableName, Item: item }).promise()
+      return item as any
+    },
+    async unlinkAccount({ provider, providerAccountId }) {
+      const data = await client
+        .query({
+          TableName,
+          IndexName: "GSI1",
+          KeyConditionExpression: "#gsi1pk = :gsi1pk AND #gsi1sk = :gsi1sk",
+          ExpressionAttributeNames: {
+            "#gsi1pk": "GSI1PK",
+            "#gsi1sk": "GSI1SK",
+          },
+          ExpressionAttributeValues: {
+            ":gsi1pk": `ACCOUNT#${provider}`,
+            ":gsi1sk": `ACCOUNT#${providerAccountId}`,
+          },
+        })
+        .promise()
+
+      const deleted = await client
+        .delete({
+          TableName,
+          Key: {
+            pk: `USER#${data.Items[0].userId as string}`,
+            sk: `ACCOUNT#${provider}#${providerAccountId}`,
+          },
+        })
+        .promise()
+
+      return deleted
+    },
+    async getSessionAndUser(sessionToken) {
+      const data = await client
+        .query({
+          TableName,
+          IndexName: "GSI1",
+          KeyConditionExpression: "#gsi1pk = :gsi1pk AND #gsi1sk = :gsi1sk",
+          ExpressionAttributeNames: {
+            "#gsi1pk": "GSI1PK",
+            "#gsi1sk": "GSI1SK",
+          },
+          ExpressionAttributeValues: {
+            ":gsi1pk": `SESSION#${sessionToken}`,
+            ":gsi1sk": `SESSION#${sessionToken}`,
+          },
+        })
+        .promise()
+
+      const session = data.Items[0] || null
+
+      if (!session || (session?.expires && new Date() > session.expires)) {
+        return null
+      }
+
+      let user = await client
+        .get({
+          TableName,
+          Key: {
+            pk: `USER#${session.userId as string}`,
+            sk: `USER#${session.userId as string}`,
+          },
+        })
+        .promise()
+
+      user = user.Item || null
+
+      if (!user) return null
+
+      return { user, session }
+    },
+    async createSession({ sessionToken, userId, expires }) {
+      const now = new Date()
+
+      const item = {
+        pk: `USER#${userId}`,
+        sk: `SESSION#${sessionToken}`,
+        GSI1SK: `SESSION#${sessionToken}`,
+        GSI1PK: `SESSION#${sessionToken}`,
+        sessionToken,
+        type: "SESSION",
+        userId,
+        expires,
+        createdAt: now.toISOString(),
+        updatedAt: now.toISOString(),
+      }
+
+      await client.put({ TableName, Item: item }).promise()
+      return item as any
+    },
+    async updateSession(data) {
+      return client
+        .update({
+          TableName,
+          Key: {
+            pk: `USER#${data.userId as string}`,
+            sk: `SESSION#${data.sessionToken}`,
+          },
+          UpdateExpression: "set #expires = :expires, #updatedAt = :updatedAt",
+          ExpressionAttributeNames: {
+            "#expires": "expires",
+            "#updatedAt": "updatedAt",
+          },
+          ExpressionAttributeValues: {
+            ":expires": (data.expires as Date).toISOString(),
+            ":updatedAt": new Date().toISOString(),
+          },
+          ReturnValues: "UPDATED_NEW",
+        })
+        .promise()
+    },
+    async deleteSession(sessionToken) {
+      const data = await client
+        .query({
+          TableName,
+          IndexName: "GSI1",
+          KeyConditionExpression: "#gsi1pk = :gsi1pk AND #gsi1sk = :gsi1sk",
+          ExpressionAttributeNames: {
+            "#gsi1pk": "GSI1PK",
+            "#gsi1sk": "GSI1SK",
+          },
+          ExpressionAttributeValues: {
+            ":gsi1pk": `SESSION#${sessionToken}`,
+            ":gsi1sk": `SESSION#${sessionToken}`,
+          },
+        })
+        .promise()
+
+      if (data?.Items?.length <= 0) return null
+
+      const infoToDelete = data.Items[0]
+
+      const deleted = await client
+        .delete({
+          TableName,
+          Key: {
+            pk: infoToDelete.pk,
+            sk: infoToDelete.sk,
+          },
+        })
+        .promise()
+
+      return deleted
+    },
+    async createVerificationToken({ identifier, expires, token }) {
+      const now = new Date()
+
+      const item = {
+        pk: `VR#${identifier}`,
+        sk: `VR#${token}`,
+        token,
+        identifier,
+        type: "VR",
+        expires,
+        createdAt: now.toISOString(),
+        updatedAt: now.toISOString(),
+      }
+
+      await client.put({ TableName, Item: item }).promise()
+
+      return item
+    },
+    async useVerificationToken({ identifier, token }) {
+      const data = await client
+        .delete({
+          TableName,
+          Key: {
+            pk: `VR#${identifier}`,
+            sk: `VR#${token}`,
+          },
+          ReturnValues: "ALL_OLD",
+        })
+        .promise()
+
+      return data?.Item
     },
   }
 }

--- a/packages/dynamodb/src/index.ts
+++ b/packages/dynamodb/src/index.ts
@@ -152,16 +152,21 @@ export function DynamoDBAdapter(
       const item = {
         pk: `USER#${data.userId}`,
         sk: `ACCOUNT#${data.provider}#${data.providerAccountId}`,
-        GSI1SK: `ACCOUNT#${data.provider}`,
-        GSI1PK: `ACCOUNT#${data.providerAccountId}`,
+        GSI1PK: `ACCOUNT#${data.provider}`,
+        GSI1SK: `ACCOUNT#${data.providerAccountId}`,
+        userId: data.userId,
         provider: data.provider,
         providerAccountId: data.providerAccountId,
-        providerType: data.providerType,
-        refreshToken: data.refreshToken,
-        accessToken: data.accessToken,
-        accessTokenExpires: data.accessTokenExpires,
-        type: "ACCOUNT",
-        userId: data.userId,
+        type: data.type,
+        accessToken: data.access_token,
+        expiresAt: data.expires_at,
+        idToken: data.id_token,
+        oauthToken: data.oauth_token,
+        oauthTokenSecret: data.oauth_token_secret,
+        refreshToken: data.refresh_token,
+        tokenType: data.token_type,
+        scope: data.scope,
+        sessionState: data.session_state,
         createdAt: now.toISOString(),
         updatedAt: now.toISOString(),
       }
@@ -248,7 +253,7 @@ export function DynamoDBAdapter(
         sessionToken,
         type: "SESSION",
         userId,
-        expires,
+        expires: expires.toISOString(),
         createdAt: now.toISOString(),
         updatedAt: now.toISOString(),
       }
@@ -319,14 +324,14 @@ export function DynamoDBAdapter(
         token,
         identifier,
         type: "VR",
-        expires,
+        expires: expires.toISOString(),
         createdAt: now.toISOString(),
         updatedAt: now.toISOString(),
       }
 
       await client.put({ TableName, Item: item }).promise()
 
-      return item
+      return { ...item, expires }
     },
     async useVerificationToken({ identifier, token }) {
       const data = await client

--- a/packages/dynamodb/src/index.ts
+++ b/packages/dynamodb/src/index.ts
@@ -144,6 +144,8 @@ export function DynamoDBAdapter(
         })
         .promise()
 
+      // TODO delete sessions and accounts
+
       return deleted
     },
     async linkAccount(data) {

--- a/packages/dynamodb/tests/index.test.ts
+++ b/packages/dynamodb/tests/index.test.ts
@@ -57,6 +57,7 @@ runBasicTests({
         expires: new Date(session.Items[0].expires),
         id: undefined, // DynamoDB does not set ID
         sessionToken: session.Items[0].sessionToken,
+        userId: session.Items[0].userId,
       }
     },
     async account({ provider, providerAccountId }) {

--- a/packages/dynamodb/tests/index.test.ts
+++ b/packages/dynamodb/tests/index.test.ts
@@ -11,6 +11,6 @@ runBasicTests({
     async user(id) {},
     async session(token) {},
     async account(id) {},
-    async verificationRequest(id) {},
+    async verificationToken(id) {},
   },
 })

--- a/packages/dynamodb/tests/index.test.ts
+++ b/packages/dynamodb/tests/index.test.ts
@@ -2,15 +2,115 @@ import { AWS } from "dynamodb"
 import { DynamoDBAdapter } from "../src"
 import { runBasicTests } from "../../../basic-tests"
 
-const client = new AWS.DynamoDB.DocumentClient()
+const client = new AWS.DynamoDB.DocumentClient({
+  region: "localhost",
+  endpoint: "http://localhost:8000",
+})
 const adapter = DynamoDBAdapter(client)
+
+const TableName = "next-auth"
 
 runBasicTests({
   adapter,
   db: {
-    async user(id) {},
-    async session(token) {},
-    async account(id) {},
-    async verificationToken(id) {},
+    async user(id) {
+      const user = await client
+        .get({
+          TableName,
+          Key: {
+            pk: `USER#${id}`,
+            sk: `USER#${id}`,
+          },
+        })
+        .promise()
+
+      if (!user.Item) return null
+
+      return {
+        email: user.Item.email,
+        id: user.Item.id,
+        image: user.Item.image,
+        name: user.Item.name,
+        emailVerified: new Date(user.Item.emailVerified),
+      }
+    },
+    async session(token) {
+      const session = await client
+        .query({
+          TableName,
+          IndexName: "GSI1",
+          KeyConditionExpression: "#gsi1pk = :gsi1pk AND #gsi1sk = :gsi1sk",
+          ExpressionAttributeNames: {
+            "#gsi1pk": "GSI1PK",
+            "#gsi1sk": "GSI1SK",
+          },
+          ExpressionAttributeValues: {
+            ":gsi1pk": `SESSION#${token}`,
+            ":gsi1sk": `SESSION#${token}`,
+          },
+        })
+        .promise()
+
+      if (!session.Items[0]) return null
+
+      return {
+        expires: new Date(session.Items[0].expires),
+        id: undefined, // DynamoDB does not set ID
+        sessionToken: session.Items[0].sessionToken,
+      }
+    },
+    async account({ provider, providerAccountId }) {
+      const account = await client
+        .query({
+          TableName,
+          IndexName: "GSI1",
+          KeyConditionExpression: "#gsi1pk = :gsi1pk AND #gsi1sk = :gsi1sk",
+          ExpressionAttributeNames: {
+            "#gsi1pk": "GSI1PK",
+            "#gsi1sk": "GSI1SK",
+          },
+          ExpressionAttributeValues: {
+            ":gsi1pk": `ACCOUNT#${provider}`,
+            ":gsi1sk": `ACCOUNT#${providerAccountId}`,
+          },
+        })
+        .promise()
+
+      if (!account.Items[0]) return null
+
+      return {
+        access_token: account.Items[0].accessToken,
+        expires_at: account.Items[0].expiresAt,
+        id_token: account.Items[0].idToken,
+        oauth_token: account.Items[0].oauthToken,
+        oauth_token_secret: account.Items[0].oauthTokenSecret,
+        refresh_token: account.Items[0].refreshToken,
+        scope: account.Items[0].scope,
+        session_state: account.Items[0].sessionState,
+        token_type: account.Items[0].tokenType,
+        type: account.Items[0].type,
+        provider: account.Items[0].provider,
+        providerAccountId: account.Items[0].providerAccountId,
+        userId: account.Items[0].userId,
+        id: undefined,
+      }
+    },
+    async verificationToken({ token, identifier }) {
+      const vt = await client
+        .get({
+          TableName,
+          Key: {
+            pk: `VR#${identifier}`,
+            sk: `VR#${token}`,
+          },
+        })
+        .promise()
+
+      return {
+        expires: new Date(vt.Item.expires),
+        token: vt.Item.token,
+        identifier: vt.Item.identifier,
+      }
+    },
   },
 })


### PR DESCRIPTION
## Reasoning 💡

Update the DynamoDB adapter to use the V4 adapter API.

## Checklist 🧢

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

Beginner with DynamoDB so may not be perfect/correct but would be looking at using this so tried to do the update.
Diff is a little painful. Maybe better to just view the file. Functions of concern:
- `getUserByAccount`
- `linkAccount`
- `unlinkAccount`