### PR TITLE
fix(typeorm-legacy): refer to entities by string instead of class

### DIFF
--- a/packages/typeorm-legacy/src/index.ts
+++ b/packages/typeorm-legacy/src/index.ts
@@ -64,9 +64,6 @@ export function TypeORMLegacyAdapter(
     },
   }
 
-  const { UserEntity, AccountEntity, SessionEntity, VerificationTokenEntity } =
-    c.entities
-
   return {
     /**
      * Method used in testing. You won't need to call this in your app.
@@ -79,27 +76,27 @@ export function TypeORMLegacyAdapter(
     // @ts-expect-error
     createUser: async (data) => {
       const m = await getManager(c)
-      const user = await m.save(UserEntity, data)
+      const user = await m.save("UserEntity", data)
       return user
     },
     // @ts-expect-error
     async getUser(id) {
       const m = await getManager(c)
-      const user = await m.findOne(UserEntity, { id })
+      const user = await m.findOne("UserEntity", { id })
       if (!user) return null
       return { ...user }
     },
     // @ts-expect-error
     async getUserByEmail(email) {
       const m = await getManager(c)
-      const user = await m.findOne(UserEntity, { email })
+      const user = await m.findOne("UserEntity", { email })
       if (!user) return null
       return { ...user }
     },
     async getUserByAccount(provider_providerAccountId) {
       const m = await getManager(c)
       const account = await m.findOne<Account & { user: AdapterUser }>(
-        AccountEntity,
+        "AccountEntity",
         provider_providerAccountId,
         { relations: ["user"] }
       )
@@ -109,39 +106,37 @@ export function TypeORMLegacyAdapter(
     // @ts-expect-error
     async updateUser(data) {
       const m = await getManager(c)
-      // @ts-expect-error
-      const user = await m.save(UserEntity, data)
+      const user = await m.save("UserEntity", data)
       return user
     },
     async deleteUser(id) {
       const m = await getManager(c)
       await m.transaction(async (tm) => {
-        await tm.delete(AccountEntity, { userId: id })
-        await tm.delete(SessionEntity, { userId: id })
-        await tm.delete(UserEntity, { id })
+        await tm.delete("AccountEntity", { userId: id })
+        await tm.delete("SessionEntity", { userId: id })
+        await tm.delete("UserEntity", { id })
       })
     },
     async linkAccount(data) {
       const m = await getManager(c)
-      const account = await m.save(AccountEntity, data)
+      const account = await m.save("AccountEntity", data)
       return account
     },
     async unlinkAccount(providerAccountId) {
       const m = await getManager(c)
-      await m.delete<Account>(AccountEntity, providerAccountId)
+      await m.delete<Account>("AccountEntity", providerAccountId)
     },
     // @ts-expect-error
     async createSession(data) {
       const m = await getManager(c)
-      // @ts-expect-error
-      const session = await m.save(SessionEntity, data)
+      const session = await m.save("SessionEntity", data)
       return session
     },
     async getSessionAndUser(sessionToken) {
       const m = await getManager(c)
       const sessionAndUser = await m.findOne<
         AdapterSession & { user: AdapterUser }
-      >(SessionEntity, { sessionToken }, { relations: ["user"] })
+      >("SessionEntity", { sessionToken }, { relations: ["user"] })
 
       if (!sessionAndUser) return null
       const { user, ...session } = sessionAndUser
@@ -149,20 +144,17 @@ export function TypeORMLegacyAdapter(
     },
     async updateSession(data) {
       const m = await getManager(c)
-      // @ts-expect-error
-      await m.update(SessionEntity, { sessionToken: data.sessionToken }, data)
+      await m.update("SessionEntity", { sessionToken: data.sessionToken }, data)
       // TODO: Try to return?
       return null
     },
     async deleteSession(sessionToken) {
       const m = await getManager(c)
-      await m.delete(SessionEntity, { sessionToken })
+      await m.delete("SessionEntity", { sessionToken })
     },
-    // @ts-expect-error
     async createVerificationToken(data) {
       const m = await getManager(c)
-      // @ts-expect-error
-      const verificationToken = await m.save(VerificationTokenEntity, data)
+      const verificationToken = await m.save("VerificationTokenEntity", data)
       // @ts-expect-error
       delete verificationToken.id
       return verificationToken
@@ -171,13 +163,13 @@ export function TypeORMLegacyAdapter(
     async useVerificationToken(identifier_token) {
       const m = await getManager(c)
       const verificationToken = await m.findOne(
-        VerificationTokenEntity,
+        "VerificationTokenEntity",
         identifier_token
       )
       if (!verificationToken) {
         return null
       }
-      await m.delete(VerificationTokenEntity, identifier_token)
+      await m.delete("VerificationTokenEntity", identifier_token)
       // @ts-expect-error
       delete verificationToken.id
       return verificationToken


### PR DESCRIPTION
## Reasoning 💡

TypeORM doesn't seem to always load entities properly on NextJS.

Also the objects are sometimes not ready after the HMR has been executed.

By referring the entities by class string instead of classes fixes the issue.

I didn't run the tests locally as I couldn't get them working on an M1 mac for some reason, but will try on a Linux later.

Bt the way, is there a reason why `await` the task inside instead of just returning the promise?

## Checklist 🧢

~- [ ] Documentation~
- [x] Tests
- [x] Ready to be merged

## Affected issues 🎟

Fixes #228
