### PR TITLE
refactor(neo4j): clean up Neo4j adapter

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,10 +6,12 @@ dynamodb:
 
 prisma:
   - packages/prisma/**/*
-  - packages/prisma-legacy/**/*
 
 mongodb:
   - packages/mongodb/**/*
+
+neo4j:
+  - packages/neo4j/**/*
 
 typeorm:
   - packages/typeorm-legacy/**/*

--- a/packages/neo4j/package.json
+++ b/packages/neo4j/package.json
@@ -8,6 +8,9 @@
     "url": "https://github.com/nextauthjs/next-auth/issues"
   },
   "author": "Davey Brown",
+  "contributors": [
+    "Balázs Orbán <info@balazsorban.com>"
+  ],
   "main": "dist/index.js",
   "license": "ISC",
   "keywords": [
@@ -31,11 +34,11 @@
   ],
   "peerDependencies": {
     "neo4j-driver": "^4.0.0",
-    "next-auth": ">=4"
+    "next-auth": ">4 || 4.0.0-beta.1 - 4.0.0-beta.x"
   },
   "devDependencies": {
-    "@types/uuid": "^8.3.0",
-    "neo4j-driver": "^4.3.0"
+    "@types/uuid": "^8.3.3",
+    "neo4j-driver": "^4.4.0"
   },
   "dependencies": {
     "uuid": "^8.3.2"

--- a/packages/neo4j/src/index.ts
+++ b/packages/neo4j/src/index.ts
@@ -149,7 +149,7 @@ export function Neo4jAdapter(session: Session): Adapter {
     },
 
     async useVerificationToken(data) {
-      const r = await write(
+      const result = await write(
         `MATCH (v:VerificationToken {
            identifier: $data.identifier,
            token: $data.token
@@ -159,7 +159,7 @@ export function Neo4jAdapter(session: Session): Adapter {
          RETURN properties`,
         data
       )
-      return format.from<any>(r?.properties)
+      return format.from<any>(result?.properties)
     },
   }
 }

--- a/packages/neo4j/src/utils.ts
+++ b/packages/neo4j/src/utils.ts
@@ -41,22 +41,6 @@ export const format = {
 }
 
 export function client(session: Session) {
-  return {
-    async read(statement: string, where: any): Promise<any> {
-      const result = await session.readTransaction((tx) =>
-        tx.run(statement, where)
-      )
-      return format.from(result?.records[0] ?? null)
-    },
-    async write<T>(statement: string, object: T): Promise<T> {
-      const data = format.to(object)
-      await session.writeTransaction((tx) => tx.run(statement, data))
-      return object
-    },
-  }
-}
-
-export function neo4jWrap(session: Session) {
   return async function query(
     statement: string,
     values?: any,

--- a/packages/neo4j/tests/index.test.ts
+++ b/packages/neo4j/tests/index.test.ts
@@ -35,7 +35,7 @@ runBasicTests({
       const result = await neo4jSession.readTransaction((tx) =>
         tx.run(
           `MATCH (u:User)-[:HAS_SESSION]->(s:Session)
-          RETURN s, u.id AS userId`,
+           RETURN s, u.id AS userId`,
           { sessionToken }
         )
       )
@@ -51,7 +51,7 @@ runBasicTests({
       const result = await neo4jSession.readTransaction((tx) =>
         tx.run(
           `MATCH (u:User)-[:HAS_ACCOUNT]->(a:Account)
-          RETURN a, u.id AS userId`,
+           RETURN a, u.id AS userId`,
           provider_providerAccountId
         )
       )

--- a/packages/neo4j/tests/index.test.ts
+++ b/packages/neo4j/tests/index.test.ts
@@ -1,112 +1,78 @@
-import neo4j from "neo4j-driver"
-
+import * as neo4j from "neo4j-driver"
 import { runBasicTests } from "../../../basic-tests"
 
-import { Neo4jAdapter } from "../src"
-import { neo4jDateToJs } from "../src/utils"
+import { Neo4jAdapter, format } from "../src"
 
-const driver: typeof neo4j.Driver = neo4j.driver(
+const driver = neo4j.driver(
   "bolt://localhost",
   neo4j.auth.basic("neo4j", "password")
 )
-const neo4jSession: typeof neo4j.Session = driver.session()
 
-const neo4jAdapter = Neo4jAdapter(neo4jSession)
+const neo4jSession = driver.session()
 
 runBasicTests({
-  adapter: neo4jAdapter,
+  adapter: Neo4jAdapter(neo4jSession),
   db: {
     async disconnect() {
       await neo4jSession.writeTransaction((tx) =>
         tx.run(
           `MATCH (n)
-          DETACH DELETE n
-          RETURN count(n)`
+           DETACH DELETE n
+           RETURN count(n)`
         )
       )
       await neo4jSession.close()
       await driver.close()
     },
-
     async user(id) {
       const result = await neo4jSession.readTransaction((tx) =>
-        tx.run(`MATCH (u:User { id: $id }) RETURN u`, {
-          id,
-        })
+        tx.run(`MATCH (u:User) RETURN u`, { id })
       )
-      const dbUser = result?.records[0]?.get("u")?.properties
-      if (!dbUser) return null
-
-      return {
-        ...dbUser,
-        emailVerified: neo4jDateToJs(dbUser?.emailVerified),
-      }
+      return format.from(result?.records[0]?.get("u")?.properties)
     },
 
     async session(sessionToken: any) {
       const result = await neo4jSession.readTransaction((tx) =>
         tx.run(
-          `MATCH (u:User)-[:HAS_SESSION]->(s:Session { sessionToken: $sessionToken })
+          `MATCH (u:User)-[:HAS_SESSION]->(s:Session)
           RETURN s, u.id AS userId`,
-          {
-            sessionToken,
-          }
+          { sessionToken }
         )
       )
-      const dbSession = result?.records[0]?.get("s")?.properties
-      const dbUserId = result?.records[0]?.get("userId")
-      if (!dbSession || !dbUserId) return null
+      const session = result?.records[0]?.get("s")?.properties
+      const userId = result?.records[0]?.get("userId")
 
-      return {
-        ...dbSession,
-        expires: neo4jDateToJs(dbSession.expires),
-        userId: dbUserId,
-      }
+      if (!session || !userId) return null
+
+      return { ...format.from(session), userId }
     },
 
     async account(provider_providerAccountId) {
       const result = await neo4jSession.readTransaction((tx) =>
         tx.run(
-          `MATCH (u:User)-[:HAS_ACCOUNT]->(a:Account { 
-            provider: $provider,
-            providerAccountId: $providerAccountId
-          })
+          `MATCH (u:User)-[:HAS_ACCOUNT]->(a:Account)
           RETURN a, u.id AS userId`,
           provider_providerAccountId
         )
       )
 
-      const dbAccount = result?.records[0]?.get("a")?.properties
-      const dbUserId = result?.records[0]?.get("userId")
-      if (!dbAccount || !dbUserId) return null
+      const account = result?.records[0]?.get("a")?.properties
+      const userId = result?.records[0]?.get("userId")
 
-      return {
-        ...dbAccount,
-        userId: dbUserId,
-      }
+      if (!account || !userId) return null
+      return { ...format.from(account), userId }
     },
 
     async verificationToken(identifier_token) {
       const result = await neo4jSession.readTransaction((tx) =>
         tx.run(
-          `
-          MATCH (v:VerificationToken {
-            identifier: $identifier,
-            token: $token 
-          })
-          RETURN v
-          `,
+          `MATCH (v:VerificationToken)
+           RETURN v`,
           identifier_token
         )
       )
 
-      const dbVerificationToken = result?.records[0]?.get("v")?.properties
-      if (!dbVerificationToken) return null
-
-      return {
-        ...dbVerificationToken,
-        expires: neo4jDateToJs(dbVerificationToken?.expires),
-      }
+      return format.from(result?.records[0]?.get("v")?.properties)
     },
   },
 })

--- a/packages/neo4j/tests/test.sh
+++ b/packages/neo4j/tests/test.sh
@@ -9,43 +9,44 @@ JEST_WATCH=false
 # Is the watch flag passed to the script?
 while getopts w flag
 do
-  case "${flag}" in
-    w) JEST_WATCH=true;;
-  esac
+    case "${flag}" in
+        w) JEST_WATCH=true;;
+        *) continue;;
+    esac
 done
 
 # Start db
 docker run -d --rm \
-  -e NEO4J_AUTH=${NEO4J_USER}/${NEO4J_PASS} \
-  -e TEST_NEO4J_USER=${NEO4J_USER} \
-  -e TEST_NEO4J_PASS=${NEO4J_PASS} \
-  --name "${CONTAINER_NAME}" \
-  -p7474:7474 -p7687:7687 \
-  -v=$SCRIPT_DIR/resources:/var/lib/neo4j/resources \
-  neo4j:4.2.0
+-e NEO4J_AUTH=${NEO4J_USER}/${NEO4J_PASS} \
+-e TEST_NEO4J_USER=${NEO4J_USER} \
+-e TEST_NEO4J_PASS=${NEO4J_PASS} \
+--name "${CONTAINER_NAME}" \
+-p7474:7474 -p7687:7687 \
+neo4j:4.2.0
+# -v="$SCRIPT_DIR"/resources:/var/lib/neo4j/resources
 
 # For debug or testing it may be useful to use neo4j enterprise edition.
 # Use the lines below in the docker run statement.
 # -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes \
 # neo4j:4.2.0-enterprise
 
-echo \"Waiting 20 sec for db to start...\" && sleep 20
+echo "Waiting 5 sec for db to start..." && sleep 5
 
-# Create constraints
-docker exec \
-  -i "${CONTAINER_NAME}" \
-  sh -c 'exec cypher-shell -u ${TEST_NEO4J_USER} -p ${TEST_NEO4J_PASS} -f /var/lib/neo4j/resources/constraints.cypher'
+# # Create constraints
+# docker exec \
+# -i "${CONTAINER_NAME}" \
+# sh -c 'exec cypher-shell -u ${TEST_NEO4J_USER} -p ${TEST_NEO4J_PASS} -f /var/lib/neo4j/resources/constraints.cypher'
 
 if $JEST_WATCH; then
-  # Run jest in watch mode
-  npx jest tests --watch
-  # Only stop the container after jest has been quit 
-  docker stop "${CONTAINER_NAME}"
+    # Run jest in watch mode
+    npx jest tests --watch
+    # Only stop the container after jest has been quit
+    docker stop "${CONTAINER_NAME}"
 else
-  # Always stop container, but exit with 1 when tests are failing
-  if npx jest tests --detectOpenHandles --forceExit;then
-      docker stop "${CONTAINER_NAME}"
-  else
-      docker stop "${CONTAINER_NAME}" && exit 1
-  fi
+    # Always stop container, but exit with 1 when tests are failing
+    if npx jest tests --detectOpenHandles --forceExit;then
+        docker stop "${CONTAINER_NAME}"
+    else
+        docker stop "${CONTAINER_NAME}" && exit 1
+    fi
 fi

--- a/yarn.lock
+++ b/yarn.lock
@@ -3259,10 +3259,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/uuid@^8.3.0":
-  version "8.3.1"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.1.tgz#1a32969cf8f0364b3d8c8af9cc3555b7805df14f"
-  integrity sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==
+"@types/uuid@^8.3.3":
+  version "8.3.3"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.3.tgz#c6a60686d953dbd1b1d45e66f4ecdbd5d471b4d0"
+  integrity sha512-0LbEEx1zxrYB3pgpd1M5lEhLcXjKJnYghvhTRgaBeUivLHMDM1TzF3IJ6hXU2+8uA4Xz+5BA63mtZo5DjVT8iA==
 
 "@types/webidl-conversions@*":
   version "6.1.1"
@@ -10016,27 +10016,27 @@ neo-async@^2.6.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-neo4j-driver-bolt-connection@^4.3.3:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/neo4j-driver-bolt-connection/-/neo4j-driver-bolt-connection-4.3.3.tgz#603734caba66b09f6a5962516d27427fd6633502"
-  integrity sha512-yCiNf4c96wUFrBflabkJ3P+2jLLxrKrjHofvnPqoaTtFBEdnFQYk6oNI+xtF4STe9ADRRrpzOQo1SI8jfmksRQ==
+neo4j-driver-bolt-connection@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/neo4j-driver-bolt-connection/-/neo4j-driver-bolt-connection-4.4.0.tgz#19bc93977f31b43ad6710750b674365d35b63003"
+  integrity sha512-hhoilDz4uoEYumoSapIL1PCC7KeMRJOdOBR75R1Mu1srC6LZGH37d4OAFG1OD7KzbJCti4NuRzNWsHnwwSzxHg==
   dependencies:
-    neo4j-driver-core "^4.3.3"
+    neo4j-driver-core "^4.4.0"
     text-encoding-utf-8 "^1.0.2"
 
-neo4j-driver-core@^4.3.3:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/neo4j-driver-core/-/neo4j-driver-core-4.3.3.tgz#600081d2d1e7dfa79ba624aafceb74c8419d947d"
-  integrity sha512-n0ltGzACnKTta/d1CGhqgcjYaWwlTIgUU0nwRRd3OZZifXcW030ICqNtwqn2t7WFmDE5iVmD2yQwo4JIvitV5g==
+neo4j-driver-core@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/neo4j-driver-core/-/neo4j-driver-core-4.4.0.tgz#b9d3a6ca53f2aa8705b387e3e0660742e7c57efa"
+  integrity sha512-Ft4g1jJXXnnXemdCMETUG/e6iY7yfGwH0n0aaUVkgr8yovEXTBEz98rFct4nso3zyqPVKVN8FeCYDA37vmT8Jw==
 
-neo4j-driver@^4.3.0:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/neo4j-driver/-/neo4j-driver-4.3.3.tgz#497383d89b0141b11926ef7cec7a91678604fd6f"
-  integrity sha512-rsBd8BB3YA8mNhQcltj3UuoTJKd07DRN5ZrtW4bKJHp9AgC28v6Q65nLYTdZZo0r+NRpxau1SlsAeqSEnLPCZA==
+neo4j-driver@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/neo4j-driver/-/neo4j-driver-4.4.0.tgz#f3b39818d14140aedf39abfdb44961abea39bc73"
+  integrity sha512-6im3OYhwyG87O0nV/7HATo/vlOQaqGqnAsrYJ4Sw0czHgv/qJJ7qMheFGTXHqNoQsn376DBKda+ikFKTfnadDA==
   dependencies:
     "@babel/runtime" "^7.5.5"
-    neo4j-driver-bolt-connection "^4.3.3"
-    neo4j-driver-core "^4.3.3"
+    neo4j-driver-bolt-connection "^4.4.0"
+    neo4j-driver-core "^4.4.0"
     rxjs "^6.6.3"
 
 netmask@^2.0.1:


### PR DESCRIPTION
Continues on #186

- extracting `from` and `to` format methods similar to other adapters
- ran Prettier
- simplified queries
- split `query` to `read` and `write` methods
- whenever possible, I drop `RETURN` from the statements, in hope that the writes are faster this way, and it would require less converting using `format`
- remove any restrictions on what data the user can pass (eg.: remove explicit `expires`, `emailVerified` etc. formatting.)

cc @EarthlingDavey

Still have problems with the `.cypher` file, even the CI publishing failed because of it https://github.com/nextauthjs/adapters/runs/4270643543?check_suite_focus=true, so for now, I just ignore it.