### PR TITLE
feat: add collectionPrefix config option to MongoDB adapter

### DIFF
--- a/packages/mongodb/README.md
+++ b/packages/mongodb/README.md
@@ -85,6 +85,22 @@ export default async function auth(req, res) {
 }
 ```
 
+Optional: Use the `collectionPrefix` configuration option to make sure that all database collections that are created have your prefix in their name. This may be necessary when you already have collections with names like `users`, `accounts`, `sessions` or `verification_tokens`. Use it like that:
+
+```
+export default async function auth(req, res) {
+  return await NextAuth(req, res, {
+    adapter: MongoDBAdapter({
+      db: (await clientPromise).db("your-database"),
+	  collectionPrefix: 'nextauth_'
+    }),
+    // https://next-auth.js.org/configuration/providers
+    providers: [],
+    ...
+  })
+}
+```
+
 ## Contributing
 
 We're open to all community contributions! If you'd like to contribute in any way, please read our [Contributing Guide](https://github.com/nextauthjs/adapters/blob/main/CONTRIBUTING.md).

--- a/packages/mongodb/src/index.ts
+++ b/packages/mongodb/src/index.ts
@@ -55,16 +55,23 @@ export function _id(hex?: string) {
   return new ObjectId(hex)
 }
 
-export function MongoDBAdapter(options: { db: MongoDB.Db }): Adapter {
-  const { db: m } = options
+export function MongoDBAdapter(options: {
+  db: MongoDB.Db
+  collectionPrefix?: string
+}): Adapter {
+  const { db: m, collectionPrefix = "" } = options
   const { from, to } = format
 
   const { Users, Accounts, Sessions, VerificationTokens } = {
-    Users: m.collection<AdapterUser>(collections.Users),
-    Accounts: m.collection<Account>(collections.Accounts),
-    Sessions: m.collection<AdapterSession>(collections.Sessions),
+    Users: m.collection<AdapterUser>(`${collectionPrefix}${collections.Users}`),
+    Accounts: m.collection<Account>(
+      `${collectionPrefix}${collections.Accounts}`
+    ),
+    Sessions: m.collection<AdapterSession>(
+      `${collectionPrefix}${collections.Sessions}`
+    ),
     VerificationTokens: m.collection<VerificationToken>(
-      collections.VerificationTokens
+      `${collectionPrefix}${collections.VerificationTokens}`
     ),
   }
   return {
@@ -100,9 +107,9 @@ export function MongoDBAdapter(options: { db: MongoDB.Db }): Adapter {
     async deleteUser(id) {
       const userId = _id(id)
       await Promise.all([
-        m.collection(collections.Accounts).deleteMany({ userId }),
-        m.collection(collections.Sessions).deleteMany({ userId }),
-        m.collection(collections.Users).deleteOne({ _id: userId }),
+        Accounts.deleteMany({ userId }),
+        Sessions.deleteMany({ userId }),
+        Users.deleteOne({ _id: userId }),
       ])
     },
     linkAccount: async (data) => {

--- a/packages/mongodb/tests/index.test.ts
+++ b/packages/mongodb/tests/index.test.ts
@@ -1,22 +1,24 @@
 import { runBasicTests } from "../../../basic-tests"
 import { collections, format, MongoDBAdapter, _id } from "../src"
 import { MongoClient } from "mongodb"
-const client = new MongoClient("mongodb://localhost:27017")
 const databaseName = "test"
-const db = client.db(databaseName)
+const collectionPrefix = "nextauth_"
+
+const client1 = new MongoClient("mongodb://localhost:27017")
+const db1 = client1.db(databaseName)
 
 runBasicTests({
-  adapter: MongoDBAdapter({ db }),
+  adapter: MongoDBAdapter({ db: db1 }),
   db: {
     async connect() {
-      return await client.connect()
+      return await client1.connect()
     },
     async disconnect() {
-      await client.db("test").dropDatabase()
-      await client.close()
+      await client1.db("test").dropDatabase()
+      await client1.close()
     },
     async user(id) {
-      const user = await client
+      const user = await client1
         .db("test")
         .collection(collections.Users)
         .findOne({ _id: _id(id) })
@@ -25,7 +27,7 @@ runBasicTests({
       return format.from(user)
     },
     async account(provider_providerAccountId) {
-      const account = await client
+      const account = await client1
         .db("test")
         .collection(collections.Accounts)
         .findOne(provider_providerAccountId)
@@ -33,7 +35,7 @@ runBasicTests({
       return format.from(account)
     },
     async session(sessionToken) {
-      const session = await client
+      const session = await client1
         .db("test")
         .collection(collections.Sessions)
         .findOne({ sessionToken })
@@ -41,12 +43,62 @@ runBasicTests({
       return format.from(session)
     },
     async verificationToken(identifier_token) {
-      const token = await client
+      const result = await client1
         .db("test")
         .collection(collections.VerificationTokens)
         .findOne(identifier_token)
-      if (!token) return null
-      delete token._id
+      if (!result) return null
+      const { _id, ...token } = result
+      return token
+    },
+  },
+})
+
+const client2 = new MongoClient("mongodb://localhost:27017")
+const db2 = client1.db(databaseName)
+
+runBasicTests({
+  adapter: MongoDBAdapter({ db: db2, collectionPrefix }),
+  db: {
+    async connect() {
+      return await client2.connect()
+    },
+    async disconnect() {
+      await client2.db("test").dropDatabase()
+      await client2.close()
+    },
+    async user(id) {
+      const user = await client2
+        .db("test")
+        .collection(`${collectionPrefix}${collections.Users}`)
+        .findOne({ _id: _id(id) })
+
+      if (!user) return null
+      return format.from(user)
+    },
+    async account(provider_providerAccountId) {
+      const account = await client2
+        .db("test")
+        .collection(`${collectionPrefix}${collections.Accounts}`)
+        .findOne(provider_providerAccountId)
+      if (!account) return null
+      return format.from(account)
+    },
+    async session(sessionToken) {
+      const session = await client2
+        .db("test")
+        .collection(`${collectionPrefix}${collections.Sessions}`)
+        .findOne({ sessionToken })
+      if (!session) return null
+      return format.from(session)
+    },
+    async verificationToken(identifier_token) {
+      const result = await client2
+        .db("test")
+        .collection(`${collectionPrefix}${collections.VerificationTokens}`)
+        .findOne(identifier_token)
+      if (!result) return null
+      const { _id, ...token } = result
       return token
     },
   },


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## Reasoning 💡

<!--
What changes are being made? What feature/bug is being fixed here?

IMPORTANT: Which, if any, adapter is being affected? Or are you wanting to add
a new one?
 -->

This adds a configuration option to the new MongoDB adapter:
The option is called `collectionPrefix` and enables the user to provide a prefix that is used for all database collection names that the adapter uses.

This was possible in next-auth v3 via the `entityPrefix` option for TypeORM.

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
Closes #321 