### PR TITLE
feat(mongodb): simplify adapter initialization

### DIFF
--- a/packages/mongodb/README.md
+++ b/packages/mongodb/README.md
@@ -73,8 +73,6 @@ import clientPromise from "lib/mongodb"
 // https://next-auth.js.org/configuration/options
 export default NextAuth({
   adapter: MongoDBAdapter(clientPromise),
-  // https://next-auth.js.org/configuration/providers
-  providers: [],
   ...
 })
 ```

--- a/packages/mongodb/README.md
+++ b/packages/mongodb/README.md
@@ -1,7 +1,7 @@
 <p align="center">
    <br/>
    <a href="https://next-auth.js.org" target="_blank"><img height="64px" src="https://next-auth.js.org/img/logo/logo-sm.png" /></a>&nbsp;&nbsp;&nbsp;&nbsp;<img height="64px" src="./logo.svg" />
-   <h3 align="center"><b>mongoDB Adapter</b> - NextAuth.js</h3>
+   <h3 align="center"><b>MongoDB Adapter</b> - NextAuth.js</h3>
    <p align="center">
    Open Source. Full Stack. Own Your Data.
    </p>
@@ -14,9 +14,7 @@
 
 ## Overview
 
-This is the mongoDB Adapter for [`next-auth`](https://next-auth.js.org). This package can only be used in conjunction with the primary `next-auth` package. It is not a standalone package.
-
-You can find the mongoDB schema in the docs at [next-auth.js.org/adapters/mongodb](https://next-auth.js.org/adapters/mongodb).
+This is the MongoDB Adapter for [`next-auth`](https://next-auth.js.org). This package can only be used in conjunction with the primary `next-auth` package. It is not a standalone package.
 
 ## Getting Started
 
@@ -73,16 +71,12 @@ import clientPromise from "lib/mongodb"
 
 // For more information on each option (and a full list of options) go to
 // https://next-auth.js.org/configuration/options
-export default async function auth(req, res) {
-  return await NextAuth(req, res, {
-    adapter: MongoDBAdapter({
-      db: (await clientPromise).db("your-database")
-    }),
-    // https://next-auth.js.org/configuration/providers
-    providers: [],
-    ...
-  })
-}
+export default NextAuth({
+  adapter: MongoDBAdapter(clientPromise),
+  // https://next-auth.js.org/configuration/providers
+  providers: [],
+  ...
+})
 ```
 
 ## Contributing

--- a/packages/mongodb/src/index.ts
+++ b/packages/mongodb/src/index.ts
@@ -9,14 +9,18 @@ import type * as MongoDB from "mongodb"
 import { ObjectId } from "mongodb"
 import { Account } from "next-auth"
 
-export interface Collections {
-  Users?: string
-  Accounts?: string
-  Sessions?: string
-  VerificationTokens?: string
+export interface MongoDBAdapterOptions {
+  collections?: {
+    Users?: string
+    Accounts?: string
+    Sessions?: string
+    VerificationTokens?: string
+  }
 }
 
-export const defaultCollections = {
+export const defaultCollections: Required<
+  Required<MongoDBAdapterOptions>["collections"]
+> = {
   Users: "users",
   Accounts: "accounts",
   Sessions: "sessions",
@@ -60,10 +64,6 @@ export const format = {
 export function _id(hex?: string) {
   if (hex?.length !== 24) return new ObjectId()
   return new ObjectId(hex)
-}
-
-export interface MongoDBAdapterOptions {
-  collections?: Collections
 }
 
 export function MongoDBAdapter(

--- a/packages/mongodb/src/index.ts
+++ b/packages/mongodb/src/index.ts
@@ -9,7 +9,14 @@ import type * as MongoDB from "mongodb"
 import { ObjectId } from "mongodb"
 import { Account } from "next-auth"
 
-export const collections = {
+export interface Collections {
+  Users?: string
+  Accounts?: string
+  Sessions?: string
+  VerificationTokens?: string
+}
+
+export const defaultCollections = {
   Users: "users",
   Accounts: "accounts",
   Sessions: "sessions",
@@ -55,71 +62,81 @@ export function _id(hex?: string) {
   return new ObjectId(hex)
 }
 
-export function MongoDBAdapter(options: { db: MongoDB.Db }): Adapter {
-  const { db: m } = options
+export interface MongoDBAdapterOptions {
+  collections?: Collections
+}
+
+export function MongoDBAdapter(
+  client: Promise<MongoDB.MongoClient>,
+  options: MongoDBAdapterOptions = {}
+): Adapter {
+  const { collections } = options
   const { from, to } = format
 
-  const { Users, Accounts, Sessions, VerificationTokens } = {
-    Users: m.collection<AdapterUser>(collections.Users),
-    Accounts: m.collection<Account>(collections.Accounts),
-    Sessions: m.collection<AdapterSession>(collections.Sessions),
-    VerificationTokens: m.collection<VerificationToken>(
-      collections.VerificationTokens
-    ),
-  }
+  const db = (async () => {
+    const _db = (await client).db()
+    const c = { ...defaultCollections, ...collections }
+    return {
+      U: _db.collection<AdapterUser>(c.Users),
+      A: _db.collection<Account>(c.Accounts),
+      S: _db.collection<AdapterSession>(c.Sessions),
+      V: _db.collection<VerificationToken>(c?.VerificationTokens),
+    }
+  })()
+
   return {
     async createUser(data) {
       const user = to<AdapterUser>(data)
-      await Users.insertOne(user)
+      await (await db).U.insertOne(user)
       return from<AdapterUser>(user)
     },
     async getUser(id) {
-      const user = await Users.findOne({ _id: _id(id) })
+      const user = await (await db).U.findOne({ _id: _id(id) })
       if (!user) return null
       return from<AdapterUser>(user)
     },
     async getUserByEmail(email) {
-      const user = await Users.findOne({ email })
+      const user = await (await db).U.findOne({ email })
       if (!user) return null
       return from<AdapterUser>(user)
     },
     async getUserByAccount(provider_providerAccountId) {
-      const account = await Accounts.findOne(provider_providerAccountId)
+      const account = await (await db).A.findOne(provider_providerAccountId)
       if (!account) return null
-      const user = await Users.findOne({ _id: account.userId })
+      const user = await (await db).U.findOne({ _id: account.userId })
       if (!user) return null
       return from<AdapterUser>(user)
     },
     async updateUser(data) {
-      const { value: user } = await Users.findOneAndUpdate(
-        { _id: _id(data.id) },
-        { $set: data }
-      )
+      const { value: user } = await (
+        await db
+      ).U.findOneAndUpdate({ _id: _id(data.id) }, { $set: data })
       return from<AdapterUser>(user!)
     },
     async deleteUser(id) {
       const userId = _id(id)
+      const m = await db
       await Promise.all([
-        m.collection(collections.Accounts).deleteMany({ userId }),
-        m.collection(collections.Sessions).deleteMany({ userId }),
-        m.collection(collections.Users).deleteOne({ _id: userId }),
+        m.A.deleteMany({ userId }),
+        m.S.deleteMany({ userId }),
+        m.U.deleteOne({ _id: userId }),
       ])
     },
     linkAccount: async (data) => {
       const account = to<Account>(data)
-      await Accounts.insertOne(account)
+      await (await db).A.insertOne(account)
       return account
     },
     async unlinkAccount(provider_providerAccountId) {
-      const { value: account } = await Accounts.findOneAndDelete(
-        provider_providerAccountId
-      )
+      const { value: account } = await (
+        await db
+      ).A.findOneAndDelete(provider_providerAccountId)
       return from<Account>(account!)
     },
     async getSessionAndUser(sessionToken) {
-      const session = await Sessions.findOne({ sessionToken })
+      const session = await (await db).S.findOne({ sessionToken })
       if (!session) return null
-      const user = await Users.findOne({ _id: session.userId })
+      const user = await (await db).U.findOne({ _id: session.userId })
       if (!user) return null
       return {
         user: from<AdapterUser>(user),
@@ -128,29 +145,31 @@ export function MongoDBAdapter(options: { db: MongoDB.Db }): Adapter {
     },
     async createSession(data) {
       const session = to<AdapterSession>(data)
-      await Sessions.insertOne(session)
+      await (await db).S.insertOne(session)
       return from<AdapterSession>(session)
     },
     async updateSession(data) {
-      const { value: session } = await Sessions.findOneAndUpdate(
-        { sessionToken: data.sessionToken },
-        { $set: data }
-      )
+      const { value: session } = await (
+        await db
+      ).S.findOneAndUpdate({ sessionToken: data.sessionToken }, { $set: data })
       return from<AdapterSession>(session!)
     },
     async deleteSession(sessionToken) {
-      const { value: session } = await Sessions.findOneAndDelete({
+      const { value: session } = await (
+        await db
+      ).S.findOneAndDelete({
         sessionToken,
       })
       return from<AdapterSession>(session!)
     },
     async createVerificationToken(data) {
-      await VerificationTokens.insertOne(to(data))
+      await (await db).V.insertOne(to(data))
       return data
     },
     async useVerificationToken(identifier_token) {
-      const { value: verificationToken } =
-        await VerificationTokens.findOneAndDelete(identifier_token)
+      const { value: verificationToken } = await (
+        await db
+      ).V.findOneAndDelete(identifier_token)
 
       if (!verificationToken) return null
       // @ts-expect-error

--- a/packages/mongodb/tests/custom.test.ts
+++ b/packages/mongodb/tests/custom.test.ts
@@ -1,13 +1,16 @@
 import { runBasicTests } from "../../../basic-tests"
 import { defaultCollections, format, MongoDBAdapter, _id } from "../src"
 import { MongoClient } from "mongodb"
-
-const name = "test"
+const name = "custom-test"
 const client = new MongoClient(`mongodb://localhost:27017/${name}`)
 const clientPromise = client.connect()
 
+const collections = { ...defaultCollections, Users: "some_userz" }
+
 runBasicTests({
-  adapter: MongoDBAdapter(clientPromise),
+  adapter: MongoDBAdapter(clientPromise, {
+    collections,
+  }),
   db: {
     async disconnect() {
       await client.db().dropDatabase()
@@ -16,7 +19,7 @@ runBasicTests({
     async user(id) {
       const user = await client
         .db()
-        .collection(defaultCollections.Users)
+        .collection(collections.Users)
         .findOne({ _id: _id(id) })
 
       if (!user) return null
@@ -25,7 +28,7 @@ runBasicTests({
     async account(provider_providerAccountId) {
       const account = await client
         .db()
-        .collection(defaultCollections.Accounts)
+        .collection(collections.Accounts)
         .findOne(provider_providerAccountId)
       if (!account) return null
       return format.from(account)
@@ -33,7 +36,7 @@ runBasicTests({
     async session(sessionToken) {
       const session = await client
         .db()
-        .collection(defaultCollections.Sessions)
+        .collection(collections.Sessions)
         .findOne({ sessionToken })
       if (!session) return null
       return format.from(session)
@@ -41,7 +44,7 @@ runBasicTests({
     async verificationToken(identifier_token) {
       const token = await client
         .db()
-        .collection(defaultCollections.VerificationTokens)
+        .collection(collections.VerificationTokens)
         .findOne(identifier_token)
       if (!token) return null
       delete token._id

--- a/packages/mongodb/tests/test.sh
+++ b/packages/mongodb/tests/test.sh
@@ -2,6 +2,14 @@
 
 CONTAINER_NAME=next-auth-mongodb-test
 
+# Is the watch flag passed to the script?
+while getopts w flag
+do
+    case "${flag}" in
+        w) JEST_WATCH=true;;
+        *) continue;;
+    esac
+done
 
 # Start db
 docker run -d --rm -p 27017:27017 --name ${CONTAINER_NAME} mongo
@@ -9,9 +17,16 @@ docker run -d --rm -p 27017:27017 --name ${CONTAINER_NAME} mongo
 echo "Waiting 3 sec for db to start..."
 sleep 3
 
-# Always stop container, but exit with 1 when tests are failing
-if npx jest;then
-    docker stop ${CONTAINER_NAME}
+if $JEST_WATCH; then
+    # Run jest in watch mode
+    npx jest tests --watch
+    # Only stop the container after jest has been quit
+    docker stop "${CONTAINER_NAME}"
 else
-    docker stop ${CONTAINER_NAME} && exit 1
+    # Always stop container, but exit with 1 when tests are failing
+    if npx jest;then
+        docker stop ${CONTAINER_NAME}
+    else
+        docker stop ${CONTAINER_NAME} && exit 1
+    fi
 fi


### PR DESCRIPTION
Looking through issues, the initialization of the MongoDB adapter has been a pain for newcomers and those used to the other adapters. I've found a way to match the other adapters' initialization process, while only requiring that the user adds the database name on their connection string.

This PR also closes #322, closes #321

Docs changes at https://github.com/nextauthjs/docs/pull/133

The new syntax is:
```js
import NextAuth from "next-auth"
import { MongoDBAdapter } from "@next-auth/mongodb-adapter"
import clientPromise from "lib/mongodb"

// For more information on each option (and a full list of options) go to
// https://next-auth.js.org/configuration/options
export default NextAuth({
  adapter: MongoDBAdapter(clientPromise),
  // https://next-auth.js.org/configuration/providers
  providers: [],
  ...
})
```

You can also pass a second parameter, that looks like this:

```ts
interface MongoDBAdapterOptions {
  collections?: {
    Users?: string
    Accounts?: string
    Sessions?: string
    VerificationTokens?: string
  }
}
```