### PR TITLE
fix(typeorm): do not parse date strings in `format`

### DIFF
--- a/packages/typeorm-legacy/src/entities.ts
+++ b/packages/typeorm-legacy/src/entities.ts
@@ -9,7 +9,7 @@ import {
 
 const transformer: Record<"date" | "bigint", ValueTransformer> = {
   date: {
-    from: (date: string | null) => date && new Date(parseInt(date, 10)),
+    from: (date: string | null) => date && new Date(date),
     to: (date?: Date) => date?.valueOf().toString(),
   },
   bigint: {


### PR DESCRIPTION
## Reasoning 💡

As far as I can tell (let me know if i'm wrong!), TypeORM returns timestamps as strings, not integers.

Without this change, SessionEntity returns the following:

```
{
  sessionAndUser: SessionEntity {
    id: 47,
    sessionToken: 'xxxxx',
    userId: 1,
    expires: Invalid Date,
    user: UserEntity {
      id: 1,
      name: 'Max Rozen',
      email: 'xxxxx',
      emailVerified: Invalid Date,
      image: 'xxxxx'
    }
  }
}
```
Which throws a SESSION_ERROR.

With this change, it returns:
```
{
  sessionAndUser: SessionEntity {
    id: 47,
    sessionToken: 'xxxxx',
    userId: 1,
    expires: 2022-01-02T07:52:58.960Z,
    user: UserEntity {
      id: 1,
      name: 'Max Rozen',
      email: 'xxxxx',
      emailVerified: 2021-07-12T22:21:36.302Z,
      image: 'xxxxx'
    }
  }
}
```

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
