### PR TITLE
fix(mikro-orm): remove option to pass in initialized MikroORM instance

### DIFF
--- a/packages/mikro-orm/README.md
+++ b/packages/mikro-orm/README.md
@@ -35,12 +35,13 @@ This is the MikroORM Adapter for [`next-auth`](https://next-auth.js.org). This p
    export default NextAuth({
       // https://next-auth.js.org/configuration/providers
       providers: [],
-      // optionally pass extended models as { entities: { } }
       adapter: MikroOrmAdapter({
          dbName: "./db.sqlite",
          type: "sqlite",
          debug: process.env.DEBUG === "true" || process.env.DEBUG?.includes("db"),
          ...
+      }, {
+         // optionally pass extended models as { entities: { } }
       }),
       ...
    });

--- a/packages/mikro-orm/README.md
+++ b/packages/mikro-orm/README.md
@@ -41,7 +41,7 @@ This is the MikroORM Adapter for [`next-auth`](https://next-auth.js.org). This p
          debug: process.env.DEBUG === "true" || process.env.DEBUG?.includes("db"),
          ...
       }, {
-         // optionally pass extended models as { entities: { } }
+         // pass extended models as { entities: { } } if needed
       }),
       ...
    });

--- a/packages/mikro-orm/package.json
+++ b/packages/mikro-orm/package.json
@@ -32,11 +32,11 @@
     "dist"
   ],
   "peerDependencies": {
-    "@mikro-orm/core": ">5 || 5.0.0-dev.527 - 5.0.0-dev.x",
+    "@mikro-orm/core": ">5 || 5.0.0-dev.622 - 5.0.0-dev.x",
     "next-auth": "^4.0.1"
   },
   "devDependencies": {
-    "@mikro-orm/core": "^5.0.0-dev.527",
-    "@mikro-orm/sqlite": "^5.0.0-dev.527"
+    "@mikro-orm/core": "^5.0.0-dev.622",
+    "@mikro-orm/sqlite": "^5.0.0-dev.622"
   }
 }

--- a/packages/mikro-orm/src/index.ts
+++ b/packages/mikro-orm/src/index.ts
@@ -19,12 +19,11 @@ export function MikroOrmAdapter(
     entities?: Partial<typeof defaultEntities>
   }
 ): Adapter {
-  const {
-    User: UserModel,
-    Account: AccountModel,
-    Session: SessionModel,
-    VerificationToken: VerificationTokenModel,
-  } = { ...defaultEntities, ...options?.entities }
+  const UserModel = options?.entities?.User ?? defaultEntities.User
+  const AccountModel = options?.entities?.Account ?? defaultEntities.Account
+  const SessionModel = options?.entities?.Session ?? defaultEntities.Session
+  const VerificationTokenModel =
+    options?.entities?.VerificationToken ?? defaultEntities.VerificationToken
 
   const getEM = async () => {
     if (!isPromise(ormConnection)) {

--- a/packages/mikro-orm/src/index.ts
+++ b/packages/mikro-orm/src/index.ts
@@ -1,8 +1,14 @@
-import type { Options } from "@mikro-orm/core"
+import type {
+  AnyEntity,
+  EntityClass,
+  EntitySchema,
+  Options,
+} from "@mikro-orm/core"
 import { MikroORM, wrap } from "@mikro-orm/core"
 import * as defaultEntities from "./entities"
 
 import type { Adapter } from "next-auth/adapters"
+import type { EntityClassGroup } from "@mikro-orm/core/dist/typings"
 
 export * as defaultEntities from "./entities"
 
@@ -13,7 +19,11 @@ export * as defaultEntities from "./entities"
  * @returns
  */
 export function MikroOrmAdapter(
-  ormOptions: Options,
+  ormOptions: Omit<Options, "entities"> & {
+    entities?: Array<
+      EntityClass<AnyEntity> | EntityClassGroup<AnyEntity> | EntitySchema<any>
+    >
+  },
   options?: {
     entities?: Partial<typeof defaultEntities>
   }
@@ -32,7 +42,7 @@ export function MikroOrmAdapter(
         throw new Error("You have to pass class entities to MikroORM.init")
 
       // filter out default entities from the passed entities
-      const connectionEntities = ormOptions.entities?.filter((e) => {
+      const optionsEntities = ormOptions.entities?.filter((e) => {
         if (typeof e !== "string" && "name" in e && typeof e.name === "string")
           return !["User", "Account", "Session", "VerificationToken"].includes(
             e.name
@@ -41,7 +51,7 @@ export function MikroOrmAdapter(
       })
       // add the (un-)enhanced entities to the connection
       ormOptions.entities = [
-        ...(connectionEntities ?? []),
+        ...(optionsEntities ?? []),
         UserModel,
         AccountModel,
         SessionModel,

--- a/packages/mikro-orm/src/index.ts
+++ b/packages/mikro-orm/src/index.ts
@@ -1,6 +1,7 @@
 import type {
   AnyEntity,
   EntityClass,
+  EntityClassGroup,
   EntitySchema,
   Options,
 } from "@mikro-orm/core"
@@ -8,7 +9,6 @@ import { MikroORM, wrap } from "@mikro-orm/core"
 import * as defaultEntities from "./entities"
 
 import type { Adapter } from "next-auth/adapters"
-import type { EntityClassGroup } from "@mikro-orm/core/dist/typings"
 
 export * as defaultEntities from "./entities"
 

--- a/packages/mikro-orm/src/index.ts
+++ b/packages/mikro-orm/src/index.ts
@@ -13,9 +13,9 @@ import type { Adapter } from "next-auth/adapters"
 export * as defaultEntities from "./entities"
 
 /**
- * The MikroORM adapter accepts a MikroORM instance or configuration and returns a NextAuth adapter.
- * @param ormConnection can either be an instance promise or a MikroORM connection configuration (https://mikro-orm.io/docs/next/configuration#driver)
- * @param options entities in the options object will be passed to the MikroORM init function as entities
+ * The MikroORM adapter accepts a MikroORM configuration and returns a NextAuth adapter.
+ * @param ormConnection a MikroORM connection configuration (https://mikro-orm.io/docs/next/configuration#driver)
+ * @param options entities in the options object will be passed to the MikroORM init function as entities. Has to be provided if overridden!
  * @returns
  */
 export function MikroOrmAdapter(

--- a/packages/mikro-orm/src/index.ts
+++ b/packages/mikro-orm/src/index.ts
@@ -38,20 +38,25 @@ export function MikroOrmAdapter(
 
   const getEM = async () => {
     if (!_orm) {
-      if (typeof ormOptions.entities === "string")
-        throw new Error("You have to pass class entities to MikroORM.init")
-
       // filter out default entities from the passed entities
-      const optionsEntities = ormOptions.entities?.filter((e) => {
-        if (typeof e !== "string" && "name" in e && typeof e.name === "string")
-          return !["User", "Account", "Session", "VerificationToken"].includes(
-            e.name
+      const optionsEntities =
+        ormOptions.entities?.filter((e) => {
+          if (
+            typeof e !== "string" &&
+            "name" in e &&
+            typeof e.name === "string"
           )
-        return true
-      })
+            return ![
+              "User",
+              "Account",
+              "Session",
+              "VerificationToken",
+            ].includes(e.name)
+          return true
+        }) ?? []
       // add the (un-)enhanced entities to the connection
       ormOptions.entities = [
-        ...(optionsEntities ?? []),
+        ...optionsEntities,
         UserModel,
         AccountModel,
         SessionModel,

--- a/packages/mikro-orm/tests/index.test.ts
+++ b/packages/mikro-orm/tests/index.test.ts
@@ -1,3 +1,4 @@
+import type { Options } from "@mikro-orm/core"
 import { MikroORM, wrap } from "@mikro-orm/core"
 import { runBasicTests } from "../../../basic-tests"
 import { MikroOrmAdapter, defaultEntities } from "../src"
@@ -13,34 +14,22 @@ const entities = [
   VeryImportantEntity,
 ]
 
+const config: Options = {
+  dbName: "./db.sqlite",
+  type: "sqlite",
+  entities,
+  debug: process.env.DEBUG === "true" || process.env.DEBUG?.includes("db"),
+}
+
 async function getORM() {
   if (_init) return _init
 
-  _init = await MikroORM.init({
-    dbName: "./db.sqlite",
-    type: "sqlite",
-    entities,
-    debug: process.env.DEBUG === "true" || process.env.DEBUG?.includes("db"),
-  })
+  _init = await MikroORM.init(config)
   return _init
 }
 
 runBasicTests({
-  adapter: MikroOrmAdapter(
-    {
-      dbName: "./db.sqlite",
-      type: "sqlite",
-      entities: [
-        defaultEntities.User,
-        defaultEntities.Account,
-        defaultEntities.Session,
-        defaultEntities.VerificationToken,
-        VeryImportantEntity,
-      ],
-      debug: process.env.DEBUG === "true" || process.env.DEBUG?.includes("db"),
-    },
-    { entities: { User } }
-  ),
+  adapter: MikroOrmAdapter(config, { entities: { User } }),
   db: {
     async connect() {
       const orm = await getORM()

--- a/yarn.lock
+++ b/yarn.lock
@@ -3050,34 +3050,34 @@
     npmlog "^4.1.2"
     write-file-atomic "^3.0.3"
 
-"@mikro-orm/core@^5.0.0-dev.527":
-  version "5.0.0-dev.540"
-  resolved "https://registry.yarnpkg.com/@mikro-orm/core/-/core-5.0.0-dev.540.tgz#4edb67bd32e3be557bf8e66625c05893895476bb"
-  integrity sha512-cjZT5Q9RVw13OyETN2MOQZgwYfF4K3vm8i+Pf7DhkFZj7dCU3IU1KZSPruxDkvWh6HA5S/fJY6f5CzXtSDXL3w==
+"@mikro-orm/core@^5.0.0-dev.622":
+  version "5.0.0-dev.622"
+  resolved "https://registry.yarnpkg.com/@mikro-orm/core/-/core-5.0.0-dev.622.tgz#6a0c4369346ff447f0b186f1aa9e077d3fcfcb70"
+  integrity sha512-U6E0Jk4eK78U1MGenUBvqW2vDaEsTOXRX/AKfeOizKRaUEpLIRRGsdODcR49C3vosf2PR98Nxxv91PZ7DQl8pw==
   dependencies:
     clone "2.1.2"
-    dotenv "10.0.0"
+    dotenv "11.0.0"
     escaya "0.0.61"
     fs-extra "10.0.0"
     globby "11.0.4"
-    mikro-orm "^5.0.0-dev.540+84b5d1b1b8"
+    mikro-orm "^5.0.0-dev.622+c6802957d1"
     reflect-metadata "0.1.13"
 
-"@mikro-orm/knex@^5.0.0-dev.540+84b5d1b1b8":
-  version "5.0.0-dev.540"
-  resolved "https://registry.yarnpkg.com/@mikro-orm/knex/-/knex-5.0.0-dev.540.tgz#0ca83bf9c81719b935a9e88e8273dc831276a670"
-  integrity sha512-iDceIFxHxldvrWfjPxF/mGxT5FuBWzdMoIpvgFEhipptU5aGXqXtbBdJcTqUDur+ECz1QQc5OrxQ+Rp3z/vnNA==
+"@mikro-orm/knex@^5.0.0-dev.622+c6802957d1":
+  version "5.0.0-dev.622"
+  resolved "https://registry.yarnpkg.com/@mikro-orm/knex/-/knex-5.0.0-dev.622.tgz#fc4221317d2d9d06846eacc663e9a34ffb08c8d8"
+  integrity sha512-DWr0l4axpSWzp4WTJpW0xxsS7rcXArI3JZO8ppwr5ePweVJEbOFSBMmIuN+88mYpuswfuu4tLb+/w+OyCDu3Hg==
   dependencies:
     fs-extra "10.0.0"
-    knex "0.95.14"
+    knex "0.95.15"
     sqlstring "2.3.2"
 
-"@mikro-orm/sqlite@^5.0.0-dev.527":
-  version "5.0.0-dev.540"
-  resolved "https://registry.yarnpkg.com/@mikro-orm/sqlite/-/sqlite-5.0.0-dev.540.tgz#ccc91ae7715afa92db5dfb1e18b9755d8e6d85a3"
-  integrity sha512-WDvBJI7FjDG9L7JvjK94BrPLZ82XixDHM0XiVjxlKIYoG7U0+ENeqzaryaRjPqE7klPLismAMrMcXzmhiwatuA==
+"@mikro-orm/sqlite@^5.0.0-dev.622":
+  version "5.0.0-dev.622"
+  resolved "https://registry.yarnpkg.com/@mikro-orm/sqlite/-/sqlite-5.0.0-dev.622.tgz#84ce08a29574a97f87d72927b77b52554d8d91cd"
+  integrity sha512-cSEQH9IK7+zcW0vu0a+BiyhvuNwVmcl8BPmthOR3DUH+TZbAnQhmY8TtIik0EFqlTafAzLsxhr9GPHmPn175Vw==
   dependencies:
-    "@mikro-orm/knex" "^5.0.0-dev.540+84b5d1b1b8"
+    "@mikro-orm/knex" "^5.0.0-dev.622+c6802957d1"
     fs-extra "10.0.0"
     sqlite3 "5.0.2"
     sqlstring-sqlite "0.1.1"
@@ -5983,10 +5983,10 @@ dot-prop@^6.0.1:
   dependencies:
     is-obj "^2.0.0"
 
-dotenv@10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
-  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
+dotenv@11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-11.0.0.tgz#ee37feddf8ada6d348a79e198312d4a8abfd1c1e"
+  integrity sha512-Fp/b504Y5W+e+FpCxTFMUZ7ZEQkQYF0rx+KZtmwixJxGQbLHrhCwo3FjZgNC8vIfrSi29PABNbMoCGD9YoiXbQ==
 
 dotenv@^6.1.0:
   version "6.2.0"
@@ -9226,10 +9226,10 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-knex@0.95.14:
-  version "0.95.14"
-  resolved "https://registry.yarnpkg.com/knex/-/knex-0.95.14.tgz#47eca7757cbc5872b7c9a3c67ae3b7ac6d00cf10"
-  integrity sha512-j4qLjWySrC/JRRVtOpoR2LcS1yBOsd7Krc6mEukPvmTDX/w11pD52Pq9FYR56/kLXGeAV8jFdWBjsZFi1mscWg==
+knex@0.95.15:
+  version "0.95.15"
+  resolved "https://registry.yarnpkg.com/knex/-/knex-0.95.15.tgz#39d7e7110a6e2ad7de5d673d2dea94143015e0e7"
+  integrity sha512-Loq6WgHaWlmL2bfZGWPsy4l8xw4pOE+tmLGkPG0auBppxpI0UcK+GYCycJcqz9W54f2LiGewkCVLBm3Wq4ur/w==
   dependencies:
     colorette "2.0.16"
     commander "^7.1.0"
@@ -9945,10 +9945,10 @@ micromatch@^4.0.4:
     braces "^3.0.1"
     picomatch "^2.2.3"
 
-mikro-orm@^5.0.0-dev.540+84b5d1b1b8:
-  version "5.0.0-dev.540"
-  resolved "https://registry.yarnpkg.com/mikro-orm/-/mikro-orm-5.0.0-dev.540.tgz#9d3b4db7d98648b2bae2f60094888d7daaf08300"
-  integrity sha512-LZcV99NCdWWBUykTSwRPLTG9XtK5gyrQnwtTStoQN1VnhelI7nnvg5gtlj7gvbaAJLOe3rrEvKi1NbAhi51zDA==
+mikro-orm@^5.0.0-dev.622+c6802957d1:
+  version "5.0.0-dev.622"
+  resolved "https://registry.yarnpkg.com/mikro-orm/-/mikro-orm-5.0.0-dev.622.tgz#b462d85ecd9072e159cd01ce4a6937d32609019e"
+  integrity sha512-8c5gOkOWoNJzm3mw60E3FAtZFneT3YCzaFnLd5TWJAQjNCxWvf/S0EvwfPdZrGbr6TK8JC5fYu7hDL+GWFM2fQ==
 
 mime-db@1.51.0, "mime-db@>= 1.43.0 < 2":
   version "1.51.0"


### PR DESCRIPTION
## Reasoning 💡

I guess passing in the ORM instance makes things unnecessarily flaky. Also the double-spread did not really work out for me.

This is a breaking change.

## Checklist 🧢

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged

## Affected issues 🎟

closes nextauthjs/next-auth#3816

TODO:

- [ ] update docs repo
- [x] update to exposed type from https://github.com/mikro-orm/mikro-orm/pull/2632