### PR TITLE
Allow larger id_token in typeorm adapter

### DIFF
--- a/packages/typeorm-legacy/src/entities.ts
+++ b/packages/typeorm-legacy/src/entities.ts
@@ -78,7 +78,7 @@ export class AccountEntity {
   @Column({ type: "varchar", nullable: true })
   scope!: string | null
 
-  @Column({ type: "varchar", nullable: true })
+  @Column({ type: "text", nullable: true })
   id_token!: string | null
 
   @Column({ type: "varchar", nullable: true })


### PR DESCRIPTION

## Reasoning 💡

This resolved my issue with sign in with Google using TypeORM and seems applicable to everyone.

This change raises the max size from 255 to 65k characters.

## Checklist 🧢

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

## Affected issues 🎟

Resolves nextauthjs/next-auth#3825

