### PR TITLE
[prisma_adapter] delete session catch P2025

### DIFF
--- a/packages/prisma/src/index.ts
+++ b/packages/prisma/src/index.ts
@@ -30,8 +30,17 @@ export function PrismaAdapter(p: PrismaClient): Adapter {
     createSession: (data) => p.session.create({ data }),
     updateSession: (data) =>
       p.session.update({ data, where: { sessionToken: data.sessionToken } }),
-    deleteSession: (sessionToken) =>
-      p.session.delete({ where: { sessionToken } }),
+    async deleteSession(sessionToken) {
+      try {
+        return await p.session.delete({ where: { sessionToken } })
+      } catch (error) {
+        // If token already used/deleted, just return null
+        // https://www.prisma.io/docs/reference/api-reference/error-reference#p2025
+        if ((error as Prisma.PrismaClientKnownRequestError).code === "P2025")
+          return null
+        throw error
+      }
+    },
     createVerificationToken: (data) => p.verificationToken.create({ data }),
     async useVerificationToken(identifier_token) {
       try {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## Reasoning 💡

When a user has a sessionToken (stored in browser cookies), and missing from the database sessions, he can't connect anymore 
The adapter wasn't catching error P2025 on deleteSession as for VerificationToken


<!--
What changes are being made? What feature/bug is being fixed here?

IMPORTANT: Which, if any, adapter is being affected? Or are you wanting to add
a new one?
 -->

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
