### PR TITLE
feat(mysql2): New adapter for projects using mysql2

### DIFF
--- a/packages/mysql2/README.md
+++ b/packages/mysql2/README.md
@@ -1,0 +1,16 @@
+# Mysql2 Adapter
+
+Draft for adapter for projects using `mysql2/promise`
+
+Example custom model:
+
+```
+MySqlAdapter(
+    mysqlConnection,
+    {
+        role: "role",
+        phone: "phone"
+    }
+)
+
+```

--- a/packages/mysql2/README.md
+++ b/packages/mysql2/README.md
@@ -1,16 +1,51 @@
 # Mysql2 Adapter
 
-Draft for adapter for projects using `mysql2/promise`
+This is a [`next-auth`](https://next-auth.js.org) adapter for projects that use
+[mysql2](https://www.npmjs.com/package/mysql2) in their projects to connect to MySQL databases.
 
-Example custom model:
+## Usage
 
+```typescript title="pages/api/auth/[...nextauth].ts"
+import NextAuth from "next-auth"
+import { Mysql2Adapter } from "@next-auth/mysql2-adapter"
+
+// provide a connectionPromise from "mysql2/promise" via mysql.createConnection or mysql.createPool
+
+export default NextAuth({
+  adapter: Mysql2Adapter(connectionPromise),
+  providers: [],
+})
 ```
-MySqlAdapter(
-    mysqlConnection,
-    {
-        role: "role",
-        phone: "phone"
-    }
-)
 
+### Extended user model
+
+If your `User` table has additional fields to the default fields (`name`, `email`, `email_verified`, `image`), you
+need to configure a mapping for the adapter like in the following example:
+
+```typescript
+const adapterConfig = {
+  extendUserModel: {
+    phone: "phone", // additional property "phone" which also named "phone" in the User database table
+    postalCode: "postal_code", // additional property "postalCode" which is named "postal_code" in the User database table
+  },
+}
+
+export default NextAuth({
+  adapter: Mysql2Adapter(connectionPromise, adapterConfig),
+  providers: [],
+})
 ```
+
+## MySQL model
+
+⚠️ The adapter expects your database follows the model defined by NextAuth.js at
+[https://next-auth.js.org/adapters/models](https://next-auth.js.org/adapters/models).
+You might want to use `./tests/seed.sql` to seed your MySQL database with the correct table structure including
+a correct _Index_ and _Foreign Key_ structure. The file only contains the table structure and no data.
+
+If you create the table structure manually, please pay attention to:
+
+- Use the namings as described in [https://next-auth.js.org/adapters/models](https://next-auth.js.org/adapters/models)
+- For `timestamptz` use `DATETIME(6)`
+- Create a _Foreign Key_ relations as described in the model, with a `ON DELETE CASCADE` attribute
+- Don't add additional fields to the `User` table that conflict with names from the other tables

--- a/packages/mysql2/README.md
+++ b/packages/mysql2/README.md
@@ -1,7 +1,7 @@
 # Mysql2 Adapter
 
 This is a [`next-auth`](https://next-auth.js.org) adapter for projects that use
-[mysql2](https://www.npmjs.com/package/mysql2) in their projects to connect to MySQL databases.
+[mysql2](https://www.npmjs.com/package/mysql2) to connect to MySQL databases.
 
 ## Usage
 
@@ -25,7 +25,7 @@ need to configure a mapping for the adapter like in the following example:
 ```typescript
 const adapterConfig = {
   extendUserModel: {
-    phone: "phone", // additional property "phone" which also named "phone" in the User database table
+    phone: "phone", // additional property "phone" which is also named "phone" in the User database table
     postalCode: "postal_code", // additional property "postalCode" which is named "postal_code" in the User database table
   },
 }
@@ -46,6 +46,6 @@ a correct _Index_ and _Foreign Key_ structure. The file only contains the table 
 If you create the table structure manually, please pay attention to:
 
 - Use the namings as described in [https://next-auth.js.org/adapters/models](https://next-auth.js.org/adapters/models)
-- For `timestamptz` use `DATETIME(6)`
+- For `timestamptz` use the `DATETIME(6)` type
 - Create a _Foreign Key_ relations as described in the model, with a `ON DELETE CASCADE` attribute
 - Don't add additional fields to the `User` table that conflict with names from the other tables

--- a/packages/mysql2/jest.config.js
+++ b/packages/mysql2/jest.config.js
@@ -1,0 +1,12 @@
+/*
+ * For a detailed explanation regarding each configuration property and type check, visit:
+ * https://jestjs.io/docs/en/configuration.html
+ */
+const { defaults: tsjPreset } = require("ts-jest/presets")
+
+module.exports = {
+  transform: {
+    ...tsjPreset.transform,
+  },
+  testEnvironment: "node",
+}

--- a/packages/mysql2/package.json
+++ b/packages/mysql2/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@next-auth/mysql2-adapter",
+  "version": "0.0.1",
+  "description": "Mysql adapter (mysql2) for next-auth.",
+  "main": "dist/index.js",
+  "scripts": {
+    "test": "jest",
+    "test-custom-model": "CUSTOM_MODEL=1 jest"
+  },
+  "author": "Philipp Schmiedel <code@philippschmiedel.com>",
+  "license": "ISC",
+  "keywords": [
+    "next-auth",
+    "next.js",
+    "oauth",
+    "mysql",
+    "adapter"
+  ],
+  "peerDependencies": {
+    "mysql2": "^2.3.3",
+    "next-auth": "^4.0.5"
+  },
+  "dependencies": {
+    "uuid": "^8.3.2"
+  }
+}

--- a/packages/mysql2/package.json
+++ b/packages/mysql2/package.json
@@ -4,6 +4,7 @@
   "description": "Mysql adapter (mysql2) for next-auth.",
   "main": "dist/index.js",
   "scripts": {
+    "build": "tsc",
     "test": "jest",
     "test-custom-model": "CUSTOM_MODEL=1 jest"
   },
@@ -16,9 +17,13 @@
     "mysql",
     "adapter"
   ],
+  "files": [
+    "README.md",
+    "dist"
+  ],
   "peerDependencies": {
-    "mysql2": "^2.3.3",
-    "next-auth": "^4.0.5"
+    "mysql2": "^2.3",
+    "next-auth": "^4.0"
   },
   "dependencies": {
     "uuid": "^8.3.2"

--- a/packages/mysql2/package.json
+++ b/packages/mysql2/package.json
@@ -27,5 +27,8 @@
   },
   "dependencies": {
     "uuid": "^8.3.2"
+  },
+  "devDependencies": {
+    "@types/uuid": "^8.3.3"
   }
 }

--- a/packages/mysql2/src/index.ts
+++ b/packages/mysql2/src/index.ts
@@ -1,0 +1,87 @@
+import type { Adapter, AdapterSession, AdapterUser } from "next-auth/adapters"
+import type { Account, Awaitable } from "next-auth"
+import type { AdapterOptions, ConnectionType } from "./types"
+import { createUser, getUser, getUserByMail } from "./lib/dao/user"
+import { createSession, deleteSession, updateSession } from "./lib/dao/session"
+import { getUserSession } from "./lib/dao/userSession"
+import { createAccount } from "./lib/dao/account"
+import { getUserAccount } from "./lib/dao/userAccount"
+
+const MySqlAdapter = (
+  connectionPromise: ConnectionType,
+  opt: AdapterOptions = {}
+): Adapter => {
+  // prevent some wrong configs
+  if (opt.extendUserModel) {
+    const extendedTableFields = Object.values(opt.extendUserModel).map((v) =>
+      typeof v === "string" ? v : v.dbField
+    )
+
+    if (
+      extendedTableFields.includes("expires") ||
+      extendedTableFields.includes("sessionToken") ||
+      extendedTableFields.includes("userId")
+    ) {
+      throw new Error(
+        "User model extensions can not include names that conflict with fields in the Session table"
+      )
+    }
+  }
+
+  return {
+    async createSession(session: {
+      sessionToken: string
+      userId: string
+      expires: Date
+    }): Promise<AdapterSession> {
+      return await createSession(session, connectionPromise)
+    },
+    async updateSession(
+      session: Partial<AdapterSession> & Pick<AdapterSession, "sessionToken">
+    ): Promise<AdapterSession | null> {
+      return await updateSession(session, connectionPromise)
+    },
+    async deleteSession(sessionToken: string): Promise<void> {
+      await deleteSession(sessionToken, connectionPromise)
+    },
+    async getSessionAndUser(
+      sessionToken: string
+    ): Promise<{ session: AdapterSession; user: AdapterUser } | null> {
+      return await getUserSession(
+        sessionToken,
+        connectionPromise,
+        opt?.extendUserModel
+      )
+    },
+    async createUser(user: Omit<AdapterUser, "id">): Promise<AdapterUser> {
+      return await createUser(user, connectionPromise, opt?.extendUserModel)
+    },
+    async getUser(id: string): Promise<AdapterUser | null> {
+      return await getUser(id, connectionPromise, opt?.extendUserModel)
+    },
+    updateUser(user: Partial<AdapterUser>): Awaitable<AdapterUser> {
+      // TODO: implement
+      const mock: AdapterUser = {
+        email: undefined,
+        emailVerified: null,
+        id: "",
+        image: undefined,
+        name: undefined,
+      }
+      return mock
+    },
+    async getUserByAccount(
+      providerAccountId: Pick<Account, "provider" | "providerAccountId">
+    ): Promise<AdapterUser | null> {
+      return await getUserAccount(providerAccountId, connectionPromise)
+    },
+    async getUserByEmail(email: string): Promise<AdapterUser | null> {
+      return await getUserByMail(email, connectionPromise, opt?.extendUserModel)
+    },
+    async linkAccount(account: Account): Promise<void> {
+      return await createAccount(account, connectionPromise)
+    },
+  }
+}
+
+export default MySqlAdapter

--- a/packages/mysql2/src/lib/dao/account.ts
+++ b/packages/mysql2/src/lib/dao/account.ts
@@ -18,6 +18,12 @@ export interface AccountRow extends RowDataPacket {
   session_state: string | null
 }
 
+/**
+ * Create account in database
+ *
+ * @param account Account data
+ * @param db Database connection
+ */
 export const createAccount = async (
   account: Account,
   db: ConnectionType
@@ -47,4 +53,24 @@ export const createAccount = async (
       ...account,
     }
   )
+}
+
+/**
+ * Deletes an account from the database
+ *
+ * @param providerAccount Account identifier
+ * @param db Database connection
+ */
+export const deleteAccount = async (
+  providerAccount: Pick<Account, "provider" | "providerAccountId">,
+  db: ConnectionType
+): Promise<void> => {
+  const { provider, providerAccountId } = providerAccount
+
+  await (
+    await db
+  ).query(`DELETE FROM Account WHERE provider = ? AND providerAccountId = ?`, [
+    provider,
+    providerAccountId,
+  ])
 }

--- a/packages/mysql2/src/lib/dao/account.ts
+++ b/packages/mysql2/src/lib/dao/account.ts
@@ -36,8 +36,9 @@ export const createAccount = async (
     sqlValues.push(`:${key}`)
   }
 
+  /* eslint-disable @typescript-eslint/prefer-ts-expect-error */
   // TODO: remove when https://github.com/sidorares/node-mysql2/issues/1265 is resolved
-  // @ts-expect-error
+  // @ts-ignore
   await (
     await db
   ).query(
@@ -53,6 +54,7 @@ export const createAccount = async (
       ...account,
     }
   )
+  /* eslint-enable @typescript-eslint/prefer-ts-expect-error */
 }
 
 /**

--- a/packages/mysql2/src/lib/dao/account.ts
+++ b/packages/mysql2/src/lib/dao/account.ts
@@ -44,9 +44,8 @@ export const createAccount = async (
   ).query(
     {
       sql: `
-        INSERT INTO Account(${sqlInsert.join(",")}) VALUES(${sqlValues.join(
-        ","
-      )})
+        INSERT INTO Account(${sqlInsert.join(",")}) 
+        VALUES(${sqlValues.join(",")})
     `,
       namedPlaceholders: true,
     },
@@ -71,8 +70,11 @@ export const deleteAccount = async (
 
   await (
     await db
-  ).query(`DELETE FROM Account WHERE provider = ? AND providerAccountId = ?`, [
-    provider,
-    providerAccountId,
-  ])
+  ).query(
+    `
+      DELETE FROM Account 
+      WHERE provider = ? AND providerAccountId = ?    
+    `,
+    [provider, providerAccountId]
+  )
 }

--- a/packages/mysql2/src/lib/dao/account.ts
+++ b/packages/mysql2/src/lib/dao/account.ts
@@ -1,0 +1,50 @@
+import type { RowDataPacket } from "mysql2"
+import type { Account } from "next-auth"
+import type { ConnectionType } from "../../types"
+
+export interface AccountRow extends RowDataPacket {
+  id: string
+  type: string
+  provider: string
+  providerAccountId: string
+  refresh_token: string | null
+  expires_at: number | null
+  token_type: string | null
+  scope: string | null
+  id_token: string | null
+  userId: string
+  oauth_token_secret: string | null
+  oauth_token: string | null
+  session_state: string | null
+}
+
+export const createAccount = async (
+  account: Account,
+  db: ConnectionType
+): Promise<void> => {
+  const sqlInsert = []
+  const sqlValues = []
+
+  for (const key of Object.keys(account)) {
+    sqlInsert.push(key)
+    sqlValues.push(`:${key}`)
+  }
+
+  // TODO: remove when https://github.com/sidorares/node-mysql2/issues/1265 is resolved
+  // @ts-expect-error
+  await (
+    await db
+  ).query(
+    {
+      sql: `
+        INSERT INTO Account(${sqlInsert.join(",")}) VALUES(${sqlValues.join(
+        ","
+      )})
+    `,
+      namedPlaceholders: true,
+    },
+    {
+      ...account,
+    }
+  )
+}

--- a/packages/mysql2/src/lib/dao/session.ts
+++ b/packages/mysql2/src/lib/dao/session.ts
@@ -1,0 +1,104 @@
+import type { ResultSetHeader, RowDataPacket } from "mysql2"
+import type { AdapterSession } from "next-auth/adapters"
+import type { ConnectionType } from "../../types"
+import { v4 as uuidv4 } from "uuid"
+
+export interface SessionRow extends RowDataPacket {
+  id: string
+  expires: Date
+  sessionToken: string
+  userId: string
+}
+
+const getSessionBy = async (
+  key: string,
+  value: string,
+  db: ConnectionType
+): Promise<AdapterSession | null> => {
+  const sqlWhere = `${key} = ?`
+
+  const [result] = await (
+    await db
+  ).query<SessionRow[]>(
+    `
+        SELECT id, expires, sessionToken, userId FROM Session WHERE ${sqlWhere} LIMIT 1
+    `,
+    [value]
+  )
+
+  if (result.length === 0) {
+    return null
+  }
+  return result[0]
+}
+
+export const getSession = async (
+  id: string,
+  db: ConnectionType
+): Promise<AdapterSession | null> => {
+  return await getSessionBy("id", id, db)
+}
+
+export const getSessionBySessionToken = async (
+  sessionToken: string,
+  db: ConnectionType
+): Promise<AdapterSession | null> => {
+  return await getSessionBy("sessionToken", sessionToken, db)
+}
+
+export const deleteSession = async (
+  sessionToken: string,
+  db: ConnectionType
+): Promise<void> => {
+  await (
+    await db
+  ).query(
+    `
+        DELETE FROM Session WHERE sessionToken = ?
+    `,
+    [sessionToken]
+  )
+}
+
+export const createSession = async (
+  session: { sessionToken: string; userId: string; expires: Date },
+  db: ConnectionType
+): Promise<AdapterSession> => {
+  const uuid = uuidv4()
+
+  await (
+    await db
+  ).query(
+    `
+        INSERT INTO Session(id, expires, sessionToken, userId) VALUES (?,?,?,?)
+    `,
+    [uuid, session.expires, session.sessionToken, session.userId]
+  )
+
+  const newSession = await getSession(uuid, db)
+  if (!newSession) {
+    throw new Error("New session was not persisted in database")
+  }
+
+  return newSession
+}
+
+export const updateSession = async (
+  session: Partial<AdapterSession> & Pick<AdapterSession, "sessionToken">,
+  db: ConnectionType
+): Promise<AdapterSession | null> => {
+  const [result] = await (
+    await db
+  ).query<ResultSetHeader>(
+    `
+        UPDATE Session SET expires = ? WHERE sessionToken = ?
+    `,
+    [session.expires, session.sessionToken]
+  )
+
+  if (result.affectedRows === 0) {
+    return null
+  }
+
+  return await getSessionBySessionToken(session.sessionToken, db)
+}

--- a/packages/mysql2/src/lib/dao/session.ts
+++ b/packages/mysql2/src/lib/dao/session.ts
@@ -10,6 +10,14 @@ export interface SessionRow extends RowDataPacket {
   userId: string
 }
 
+/**
+ * Helper to retrieve Sessions by different conditions
+ *
+ * @private
+ * @param key Database field for WHERE
+ * @param value Filter value
+ * @param db Database connection
+ */
 const getSessionBy = async (
   key: string,
   value: string,
@@ -32,6 +40,12 @@ const getSessionBy = async (
   return result[0]
 }
 
+/**
+ * Get session from database
+ *
+ * @param id Session ID
+ * @param db Database connection
+ */
 export const getSession = async (
   id: string,
   db: ConnectionType
@@ -39,6 +53,12 @@ export const getSession = async (
   return await getSessionBy("id", id, db)
 }
 
+/**
+ * Get session from database by session token
+ *
+ * @param sessionToken Session token
+ * @param db Database connection
+ */
 export const getSessionBySessionToken = async (
   sessionToken: string,
   db: ConnectionType
@@ -46,6 +66,12 @@ export const getSessionBySessionToken = async (
   return await getSessionBy("sessionToken", sessionToken, db)
 }
 
+/**
+ * Delete session from database
+ *
+ * @param sessionToken Session token
+ * @param db Database connection
+ */
 export const deleteSession = async (
   sessionToken: string,
   db: ConnectionType
@@ -60,6 +86,12 @@ export const deleteSession = async (
   )
 }
 
+/**
+ * Create session in database
+ *
+ * @param session Session data
+ * @param db Database connection
+ */
 export const createSession = async (
   session: { sessionToken: string; userId: string; expires: Date },
   db: ConnectionType
@@ -83,6 +115,12 @@ export const createSession = async (
   return newSession
 }
 
+/**
+ * Update session in database
+ *
+ * @param session Session data
+ * @param db Database connection
+ */
 export const updateSession = async (
   session: Partial<AdapterSession> & Pick<AdapterSession, "sessionToken">,
   db: ConnectionType

--- a/packages/mysql2/src/lib/dao/user.ts
+++ b/packages/mysql2/src/lib/dao/user.ts
@@ -134,7 +134,7 @@ export const createUser = async (
     {
       sql: `
         INSERT INTO User(${sqlInsert}) VALUES(${sqlValues})
-    `,
+      `,
       namedPlaceholders: true,
     },
     {
@@ -172,7 +172,7 @@ export const updateUser = async (
     {
       sql: `
         UPDATE User SET ${sqlSet.join(",")} WHERE id = :id
-    `,
+      `,
       namedPlaceholders: true,
     },
     {

--- a/packages/mysql2/src/lib/dao/user.ts
+++ b/packages/mysql2/src/lib/dao/user.ts
@@ -124,8 +124,10 @@ export const createUser = async (
   ].join(",")
 
   const newUserid = uuidv4()
+
+  /* eslint-disable @typescript-eslint/prefer-ts-expect-error */
   // TODO: remove when https://github.com/sidorares/node-mysql2/issues/1265 is resolved
-  // @ts-expect-error
+  // @ts-ignore
   await (
     await db
   ).query(
@@ -140,6 +142,7 @@ export const createUser = async (
       id: newUserid,
     }
   )
+  /* eslint-enable @typescript-eslint/prefer-ts-expect-error */
 
   const newUser = await getUser(newUserid, db, ext)
   if (!newUser) {
@@ -159,8 +162,10 @@ export const updateUser = async (
   }
 
   const sqlSet = generateSetQuery(user, ext)
+
+  /* eslint-disable @typescript-eslint/prefer-ts-expect-error */
   // TODO: remove when https://github.com/sidorares/node-mysql2/issues/1265 is resolved
-  // @ts-expect-error
+  // @ts-ignore
   await (
     await db
   ).query(
@@ -174,6 +179,7 @@ export const updateUser = async (
       ...user,
     }
   )
+  /* eslint-enable @typescript-eslint/prefer-ts-expect-error */
 
   const updatedUser = await getUser(user.id, db, ext)
   if (!updatedUser) {

--- a/packages/mysql2/src/lib/dao/user.ts
+++ b/packages/mysql2/src/lib/dao/user.ts
@@ -1,0 +1,116 @@
+import type { AdapterUser } from "next-auth/adapters"
+import type { RowDataPacket } from "mysql2"
+import type { ConnectionType, ModelExtension } from "../../types"
+import { v4 as uuidv4 } from "uuid"
+import { extendInsertValuesQuery, extendSelectQuery } from "../utils"
+
+interface UserRow extends RowDataPacket {
+  id: string
+  name: string
+  email: string
+  email_verified: Date
+  image: string
+}
+
+export interface MappedUserRow extends Exclude<UserRow, "email_verified"> {
+  emailVerified: Date
+}
+
+const getUserBy = async (
+  key: string,
+  value: string,
+  db: ConnectionType,
+  ext: ModelExtension = {}
+): Promise<AdapterUser | null> => {
+  const sqlSelect = [
+    "id",
+    "name",
+    "email",
+    "email_verified AS emailVerified",
+    "image",
+    ...extendSelectQuery(ext),
+  ].join(",")
+
+  const sqlWhere = `${key} = ?`
+
+  const [result] = await (
+    await db
+  ).query<MappedUserRow[]>(
+    `
+        SELECT ${sqlSelect} FROM User WHERE ${sqlWhere} LIMIT 1
+    `,
+    [value]
+  )
+
+  if (result.length === 0) {
+    return null
+  }
+
+  return result[0]
+}
+
+export const getUser = async (
+  id: string,
+  db: ConnectionType,
+  ext: ModelExtension = {}
+): Promise<AdapterUser | null> => {
+  return await getUserBy("id", id, db, ext)
+}
+
+export const getUserByMail = async (
+  mail: string,
+  db: ConnectionType,
+  ext: ModelExtension = {}
+): Promise<AdapterUser | null> => {
+  return await getUserBy("email", mail, db, ext)
+}
+
+export const createUser = async (
+  user: Omit<AdapterUser, "id">,
+  db: ConnectionType,
+  ext: ModelExtension = {}
+): Promise<AdapterUser> => {
+  const { insert: extendedInsert, values: extendedValues } =
+    extendInsertValuesQuery(ext, user)
+  const sqlInsert = [
+    "id",
+    "name",
+    "email",
+    "email_verified",
+    "image",
+    ...extendedInsert,
+  ].join(",")
+  const sqlValues = [
+    ":id",
+    ":name",
+    ":email",
+    ":emailVerified",
+    ":image",
+    ...extendedValues,
+  ].join(",")
+
+  const newUserid = uuidv4()
+  // TODO: remove when https://github.com/sidorares/node-mysql2/issues/1265 is resolved
+  // @ts-expect-error
+  await (
+    await db
+  ).query(
+    {
+      sql: `
+        INSERT INTO User(${sqlInsert}) VALUES(${sqlValues})
+    `,
+      namedPlaceholders: true,
+    },
+    {
+      ...user,
+      id: newUserid,
+    }
+  )
+
+  const newUser = await getUser(newUserid, db, ext)
+  if (!newUser) {
+    throw new Error("New user was not persisted in database")
+  }
+
+  return newUser
+}

--- a/packages/mysql2/src/lib/dao/userAccount.ts
+++ b/packages/mysql2/src/lib/dao/userAccount.ts
@@ -4,6 +4,13 @@ import type { ConnectionType, ModelExtension } from "../../types"
 import type { Account } from "next-auth"
 import { extendSelectQuery } from "../utils"
 
+/**
+ * Retrieve user and account data by account identifiers
+ *
+ * @param providerAccountId Account identifier
+ * @param db Database connection
+ * @param ext User model extension (optional)
+ */
 export const getUserAccount = async (
   providerAccountId: Pick<Account, "provider" | "providerAccountId">,
   db: ConnectionType,

--- a/packages/mysql2/src/lib/dao/userAccount.ts
+++ b/packages/mysql2/src/lib/dao/userAccount.ts
@@ -1,0 +1,32 @@
+import type { AdapterUser } from "next-auth/adapters"
+import type { MappedUserRow } from "./user"
+import type { ConnectionType, ModelExtension } from "../../types"
+import type { Account } from "next-auth"
+import { extendSelectQuery } from "../utils"
+
+export const getUserAccount = async (
+  providerAccountId: Pick<Account, "provider" | "providerAccountId">,
+  db: ConnectionType,
+  ext: ModelExtension = {}
+): Promise<AdapterUser | null> => {
+  const sqlSelect = [
+    "User.id AS id",
+    "name",
+    "email",
+    "email_verified AS emailVerified",
+    "image",
+    ...extendSelectQuery(ext),
+  ].join(",")
+  const [[result]] = await (
+    await db
+  ).query<MappedUserRow[]>(
+    `
+        SELECT ${sqlSelect} FROM Account
+        INNER JOIN User ON (userId = User.id)
+        WHERE provider = ? AND providerAccountId = ?
+    `,
+    [providerAccountId.provider, providerAccountId.providerAccountId]
+  )
+
+  return result ?? null
+}

--- a/packages/mysql2/src/lib/dao/userSession.ts
+++ b/packages/mysql2/src/lib/dao/userSession.ts
@@ -15,6 +15,13 @@ interface UserSession {
   user: AdapterUser
 }
 
+/**
+ * Retrieve user and session data by session token
+ *
+ * @param sessionToken Session token
+ * @param db Database connection
+ * @param ext User model extension (optional)
+ */
 export const getUserSession = async (
   sessionToken: string,
   db: ConnectionType,

--- a/packages/mysql2/src/lib/dao/userSession.ts
+++ b/packages/mysql2/src/lib/dao/userSession.ts
@@ -1,0 +1,65 @@
+import type { AdapterSession, AdapterUser } from "next-auth/adapters"
+import type { MappedUserRow } from "./user"
+import type { SessionRow } from "./session"
+import type { ConnectionType, ModelExtension } from "../../types"
+import { extendSelectQuery } from "../utils"
+
+interface UserSessionRow
+  extends Exclude<MappedUserRow, "id">,
+    Exclude<SessionRow, "id"> {
+  sessionId: string
+}
+
+interface UserSession {
+  session: AdapterSession
+  user: AdapterUser
+}
+
+export const getUserSession = async (
+  sessionToken: string,
+  db: ConnectionType,
+  ext: ModelExtension = {}
+): Promise<UserSession | null> => {
+  const sqlSelect = [
+    "name",
+    "email",
+    "email_verified AS emailVerified",
+    "image",
+    ...extendSelectQuery(ext),
+    "Session.id AS sessionId",
+    "expires",
+    "sessionToken",
+    "userId",
+  ].join(",")
+  const [[result]] = await (
+    await db
+  ).query<UserSessionRow[]>(
+    `
+        SELECT ${sqlSelect} FROM Session
+        INNER JOIN User ON (userId = User.id)
+        WHERE sessionToken = ?
+    `,
+    [sessionToken]
+  )
+
+  if (!result) {
+    return null
+  }
+
+  const userData: AdapterUser = { ...result, id: result.userId }
+  const sessionData: AdapterSession = {
+    id: result.sessionId,
+    expires: result.expires,
+    sessionToken: result.sessionToken,
+    userId: result.userId,
+  }
+  delete userData.sessionId
+  delete userData.expires
+  delete userData.sessionToken
+  delete userData.userId
+
+  return {
+    user: userData,
+    session: sessionData,
+  }
+}

--- a/packages/mysql2/src/lib/dao/verificationToken.ts
+++ b/packages/mysql2/src/lib/dao/verificationToken.ts
@@ -1,0 +1,81 @@
+import type { VerificationToken } from "next-auth/adapters"
+import type { ConnectionType } from "../../types"
+import type { RowDataPacket } from "mysql2"
+
+interface VerificationTokenRow extends RowDataPacket {
+  token: string
+  expires: Date
+  identifier: string
+}
+
+/**
+ * Get verification token from database
+ *
+ * @param identifier
+ * @param token
+ * @param db Database connection
+ */
+export const getVerificationToken = async (
+  identifier: string,
+  token: string,
+  db: ConnectionType
+): Promise<VerificationToken | null> => {
+  const [[result]] = await (
+    await db
+  ).query<VerificationTokenRow[]>(
+    `
+        SELECT token, expires, identifier FROM VerificationToken WHERE identifier = ? AND token = ?
+    `,
+    [identifier, token]
+  )
+
+  return result ?? null
+}
+
+/**
+ * Create verification token in database
+ *
+ * @param verificationToken
+ * @param db Database connection
+ */
+export const createVerificationToken = async (
+  verificationToken: VerificationToken,
+  db: ConnectionType
+): Promise<VerificationToken> => {
+  await (
+    await db
+  ).query(
+    `
+        INSERT INTO VerificationToken(token, expires, identifier) VALUES (?,?,?)
+    `,
+    [
+      verificationToken.token,
+      verificationToken.expires,
+      verificationToken.identifier,
+    ]
+  )
+
+  return verificationToken
+}
+
+/**
+ * Delete verification token form database
+ *
+ * @param identifier
+ * @param token
+ * @param db Database connection
+ */
+export const deleteVerificationToken = async (
+  identifier: string,
+  token: string,
+  db: ConnectionType
+): Promise<void> => {
+  await (
+    await db
+  ).query<VerificationTokenRow[]>(
+    `
+        DELETE FROM VerificationToken WHERE identifier = ? AND token = ?
+    `,
+    [identifier, token]
+  )
+}

--- a/packages/mysql2/src/lib/utils.test.ts
+++ b/packages/mysql2/src/lib/utils.test.ts
@@ -1,0 +1,227 @@
+import type { ModelExtension } from "../types"
+import type { AdapterUser } from "next-auth/adapters"
+import {
+  extendInsertValuesQuery,
+  extendSelectQuery,
+  generateSetQuery,
+} from "./utils"
+
+describe("extendSelectQuery", () => {
+  test("Empty result if no extension is given", () => {
+    const ext: ModelExtension = {}
+    const sqlParts = extendSelectQuery(ext)
+
+    expect(sqlParts).toEqual([])
+  })
+  test("Extension equal mapping", () => {
+    const ext: ModelExtension = { phoneNumber: "phoneNumber" }
+    const sqlParts = extendSelectQuery(ext)
+
+    expect(sqlParts).toEqual(["phoneNumber AS phoneNumber"])
+  })
+  test("Extension unequal mapping", () => {
+    const ext: ModelExtension = { phoneNumber: "phone_number" }
+    const sqlParts = extendSelectQuery(ext)
+
+    expect(sqlParts).toEqual(["phone_number AS phoneNumber"])
+  })
+  test("Extension config object", () => {
+    const ext: ModelExtension = { phoneNumber: { dbField: "phone_number" } }
+    const sqlParts = extendSelectQuery(ext)
+
+    expect(sqlParts).toEqual(["phone_number AS phoneNumber"])
+  })
+  test("Extension multiple entries", () => {
+    const ext: ModelExtension = {
+      phoneNumber: { dbField: "phone_number" },
+      avatarUrl: "avatar_url",
+    }
+    const sqlParts = extendSelectQuery(ext)
+
+    expect(sqlParts).toEqual([
+      "phone_number AS phoneNumber",
+      "avatar_url AS avatarUrl",
+    ])
+  })
+})
+
+describe("generateSetQuery", () => {
+  const exampleData: AdapterUser = {
+    id: "123",
+    name: "Joe Doe",
+    emailVerified: new Date(),
+  }
+
+  test("Default parameters", () => {
+    const ext: ModelExtension = {}
+    const sqlParts = generateSetQuery(exampleData, ext)
+
+    expect(sqlParts).toEqual([
+      "id = :id",
+      "name = :name",
+      "email_verified = :emailVerified",
+    ])
+  })
+  test("Changed default mapping", () => {
+    const ext: ModelExtension = {}
+    const sqlParts = generateSetQuery(exampleData, ext, { name: "user_name" })
+
+    expect(sqlParts).toEqual([
+      "id = :id",
+      "user_name = :name",
+      "emailVerified = :emailVerified",
+    ])
+  })
+  test("Extension equal mapping", () => {
+    const ext: ModelExtension = { phoneNumber: "phoneNumber" }
+    const extendedExampleData = { ...exampleData, phoneNumber: "+1234566789" }
+    const sqlParts = generateSetQuery(extendedExampleData, ext)
+
+    expect(sqlParts).toEqual([
+      "id = :id",
+      "name = :name",
+      "email_verified = :emailVerified",
+      "phoneNumber = :phoneNumber",
+    ])
+  })
+  test("Extension unequal mapping", () => {
+    const ext: ModelExtension = { phoneNumber: "phone_number" }
+    const extendedExampleData = { ...exampleData, phoneNumber: "+1234566789" }
+    const sqlParts = generateSetQuery(extendedExampleData, ext)
+
+    expect(sqlParts).toEqual([
+      "id = :id",
+      "name = :name",
+      "email_verified = :emailVerified",
+      "phone_number = :phoneNumber",
+    ])
+  })
+  test("Extension config object", () => {
+    const ext: ModelExtension = { phoneNumber: { dbField: "phone_number" } }
+    const extendedExampleData = { ...exampleData, phoneNumber: "+1234566789" }
+    const sqlParts = generateSetQuery(extendedExampleData, ext)
+
+    expect(sqlParts).toEqual([
+      "id = :id",
+      "name = :name",
+      "email_verified = :emailVerified",
+      "phone_number = :phoneNumber",
+    ])
+  })
+  test("Extension multiple entries", () => {
+    const ext: ModelExtension = {
+      phoneNumber: { dbField: "phone_number" },
+      avatarUrl: "avatar_url",
+    }
+    const extendedExampleData = {
+      ...exampleData,
+      phoneNumber: "+1234566789",
+      avatarUrl: "https://example.org/avatar.png",
+    }
+    const sqlParts = generateSetQuery(extendedExampleData, ext)
+
+    expect(sqlParts).toEqual([
+      "id = :id",
+      "name = :name",
+      "email_verified = :emailVerified",
+      "phone_number = :phoneNumber",
+      "avatar_url = :avatarUrl",
+    ])
+  })
+  test("Does not contain statements for not existing data keys", () => {
+    const ext: ModelExtension = {
+      phoneNumber: { dbField: "phone_number" },
+      avatarUrl: "avatar_url",
+    }
+    const reducedExampleData = {
+      name: "Mr Anderson",
+      phoneNumber: "+987654321",
+    }
+    const sqlParts = generateSetQuery(reducedExampleData, ext)
+
+    expect(sqlParts).toEqual(["name = :name", "phone_number = :phoneNumber"])
+  })
+})
+
+describe("extendInsertValuesQuery", () => {
+  const exampleData: AdapterUser = {
+    id: "123",
+    name: "Joe Doe",
+    emailVerified: new Date(),
+  }
+
+  test("Empty result if no extension is given", () => {
+    const ext: ModelExtension = {}
+    const { insert, values } = extendInsertValuesQuery(exampleData, ext)
+
+    expect(insert).toEqual([])
+    expect(values).toEqual([])
+  })
+  test("Extension equal mapping", () => {
+    const ext: ModelExtension = { phoneNumber: "phoneNumber" }
+    const extendedExampleData = { ...exampleData, phoneNumber: "+1234566789" }
+    const { insert, values } = extendInsertValuesQuery(extendedExampleData, ext)
+
+    expect(insert).toEqual(["phoneNumber"])
+    expect(values).toEqual([":phoneNumber"])
+  })
+  test("Extension unequal mapping", () => {
+    const ext: ModelExtension = { phoneNumber: "phone_number" }
+    const extendedExampleData = { ...exampleData, phoneNumber: "+1234566789" }
+    const { insert, values } = extendInsertValuesQuery(extendedExampleData, ext)
+
+    expect(insert).toEqual(["phone_number"])
+    expect(values).toEqual([":phoneNumber"])
+  })
+  test("Extension config object", () => {
+    const ext: ModelExtension = { phoneNumber: { dbField: "phone_number" } }
+    const extendedExampleData = { ...exampleData, phoneNumber: "+1234566789" }
+    const { insert, values } = extendInsertValuesQuery(extendedExampleData, ext)
+
+    expect(insert).toEqual(["phone_number"])
+    expect(values).toEqual([":phoneNumber"])
+  })
+  test("Extension multiple entries", () => {
+    const ext: ModelExtension = {
+      phoneNumber: { dbField: "phone_number" },
+      avatarUrl: "avatar_url",
+    }
+    const extendedExampleData = {
+      ...exampleData,
+      phoneNumber: "+1234566789",
+      avatarUrl: "https://example.org/avatar.png",
+    }
+    const { insert, values } = extendInsertValuesQuery(extendedExampleData, ext)
+
+    expect(insert).toEqual(["phone_number", "avatar_url"])
+    expect(values).toEqual([":phoneNumber", ":avatarUrl"])
+  })
+  test("Does not contain statements for not existing data keys", () => {
+    const ext: ModelExtension = {
+      phoneNumber: { dbField: "phone_number" },
+      avatarUrl: "avatar_url",
+    }
+    const reducedExampleData = {
+      phoneNumber: "+987654321",
+    }
+    const { insert, values } = extendInsertValuesQuery(reducedExampleData, ext)
+
+    expect(insert).toEqual(["phone_number"])
+    expect(values).toEqual([":phoneNumber"])
+  })
+  test("Does only contain extended data model statements", () => {
+    const ext: ModelExtension = {
+      phoneNumber: { dbField: "phone_number" },
+      avatarUrl: "avatar_url",
+    }
+    const reducedExampleData = {
+      name: "Mr Anderson",
+      phoneNumber: "+987654321",
+      avatarUrl: "https://example.org/avatar2.png",
+    }
+    const { insert, values } = extendInsertValuesQuery(reducedExampleData, ext)
+
+    expect(insert).toEqual(["phone_number", "avatar_url"])
+    expect(values).toEqual([":phoneNumber", ":avatarUrl"])
+  })
+})

--- a/packages/mysql2/src/lib/utils.ts
+++ b/packages/mysql2/src/lib/utils.ts
@@ -4,7 +4,7 @@ import type { ModelExtension } from "../types"
  * Generated SQL statements that extends the SELECT part for the given extended
  * model.
  *
- * @param ext
+ * @param ext Model extension (optional)
  */
 export const extendSelectQuery = (ext: ModelExtension): string[] => {
   const queryParts = []
@@ -16,15 +16,17 @@ export const extendSelectQuery = (ext: ModelExtension): string[] => {
 }
 
 /**
- * Generates SQL statements that extend the SET part for the given extended
+ * Generates SQL statements for the SET part for the given data and extension
  * model. Mysql2 named parameters are used in the statement like `db_property = :dbProperty`
  *
- * @param ext
- * @param data
+ * @param data Data (the complete data including default and extension!)
+ * @param ext Model extension (optional)
+ * @param defaultMapping Mapping that applies to the default data model (optional)
  */
-export const extendSetQuery = (
+export const generateSetQuery = (
+  data: Record<string, any>,
   ext: ModelExtension,
-  data: { [key: string]: any }
+  defaultMapping: Record<string, string> = { emailVerified: "email_verified" }
 ): string[] => {
   const setParts = []
   for (const key of Object.keys(data)) {
@@ -33,6 +35,10 @@ export const extendSetQuery = (
       const extSetting = ext[key]
       const dbField =
         typeof extSetting === "string" ? extSetting : extSetting.dbField
+      setParts.push(`${dbField} = :${key}`)
+      // default user data
+    } else {
+      const dbField = defaultMapping[key] ? defaultMapping[key] : key
       setParts.push(`${dbField} = :${key}`)
     }
   }
@@ -43,12 +49,12 @@ export const extendSetQuery = (
  * Generates SQL statements that extend the INSERT and VALUES part for the given extended
  * model. Mysql2 named parameters are used in the statement like `db_property = :dbProperty`
  *
- * @param ext
  * @param data
+ * @param ext Model extension (optional)
  */
 export const extendInsertValuesQuery = (
-  ext: ModelExtension,
-  data: { [key: string]: any }
+  data: { [key: string]: any },
+  ext: ModelExtension
 ): { insert: string[]; values: string[] } => {
   const insertParts = []
   const valuesParts = []

--- a/packages/mysql2/src/lib/utils.ts
+++ b/packages/mysql2/src/lib/utils.ts
@@ -1,0 +1,66 @@
+import type { ModelExtension } from "../types"
+
+/**
+ * Generated SQL statements that extends the SELECT part for the given extended
+ * model.
+ *
+ * @param ext
+ */
+export const extendSelectQuery = (ext: ModelExtension): string[] => {
+  const queryParts = []
+  for (const [key, cfg] of Object.entries(ext)) {
+    const dbField = typeof cfg === "string" ? cfg : cfg.dbField
+    queryParts.push(`${dbField} AS ${key}`)
+  }
+  return queryParts
+}
+
+/**
+ * Generates SQL statements that extend the SET part for the given extended
+ * model. Mysql2 named parameters are used in the statement like `db_property = :dbProperty`
+ *
+ * @param ext
+ * @param data
+ */
+export const extendSetQuery = (
+  ext: ModelExtension,
+  data: { [key: string]: any }
+): string[] => {
+  const setParts = []
+  for (const key of Object.keys(data)) {
+    // is extended model data?
+    if (ext[key]) {
+      const extSetting = ext[key]
+      const dbField =
+        typeof extSetting === "string" ? extSetting : extSetting.dbField
+      setParts.push(`${dbField} = :${key}`)
+    }
+  }
+  return setParts
+}
+
+/**
+ * Generates SQL statements that extend the INSERT and VALUES part for the given extended
+ * model. Mysql2 named parameters are used in the statement like `db_property = :dbProperty`
+ *
+ * @param ext
+ * @param data
+ */
+export const extendInsertValuesQuery = (
+  ext: ModelExtension,
+  data: { [key: string]: any }
+): { insert: string[]; values: string[] } => {
+  const insertParts = []
+  const valuesParts = []
+  for (const key of Object.keys(data)) {
+    // is extended model data?
+    if (ext[key]) {
+      const extSetting = ext[key]
+      const dbField =
+        typeof extSetting === "string" ? extSetting : extSetting.dbField
+      insertParts.push(`${dbField}`)
+      valuesParts.push(`:${key}`)
+    }
+  }
+  return { insert: insertParts, values: valuesParts }
+}

--- a/packages/mysql2/src/types.ts
+++ b/packages/mysql2/src/types.ts
@@ -1,0 +1,17 @@
+import type {
+  Connection as ConnectionPromise,
+  Pool as PoolPromise,
+} from "mysql2/promise"
+
+export type ConnectionType = Promise<ConnectionPromise> | Promise<PoolPromise>
+
+interface ModelExtensionOptions {
+  dbField: string
+}
+export interface ModelExtension {
+  [key: string]: string | ModelExtensionOptions
+}
+
+export interface AdapterOptions {
+  extendUserModel?: ModelExtension
+}

--- a/packages/mysql2/src/types.ts
+++ b/packages/mysql2/src/types.ts
@@ -3,15 +3,20 @@ import type {
   Pool as PoolPromise,
 } from "mysql2/promise"
 
+/*
+ * Adapter supports mysql2 Connection and Pool promise
+ */
 export type ConnectionType = Promise<ConnectionPromise> | Promise<PoolPromise>
 
+/*
+ * Interface to describe User Model extensions for this adapter
+ */
 interface ModelExtensionOptions {
   dbField: string
 }
 export interface ModelExtension {
   [key: string]: string | ModelExtensionOptions
 }
-
 export interface AdapterOptions {
   extendUserModel?: ModelExtension
 }

--- a/packages/mysql2/tests/docker-compose.yml
+++ b/packages/mysql2/tests/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.3'
+
+# connect to DB: mysql -hlocalhost --protocol=TCP -u root -p
+# seed DB: mysql -hlocalhost --protocol=TCP -u root -p nextauth-test < seed.sql
+
+services:
+  db:
+    image: mysql/mysql-server:8.0
+    restart: always
+    environment:
+      MYSQL_DATABASE: 'nextauth-test'
+      MYSQL_ROOT_PASSWORD: 'test'
+      MYSQL_ROOT_HOST: '%'
+    ports:
+      - '3306:3306'
+    expose:
+      - '3306'

--- a/packages/mysql2/tests/index.test.ts
+++ b/packages/mysql2/tests/index.test.ts
@@ -27,6 +27,7 @@ const testOptions: TestOptions = {
       await (await mysqlConnection).execute("DELETE FROM Account")
       await (await mysqlConnection).execute("DELETE FROM Session")
       await (await mysqlConnection).execute("DELETE FROM User")
+      await (await mysqlConnection).execute("DELETE FROM VerificationToken")
     },
     disconnect: async () => {
       await (await mysqlConnection).end()
@@ -74,8 +75,15 @@ const testOptions: TestOptions = {
 
       return account
     },
-    verificationToken: (params) => {
-      return {}
+    verificationToken: async (params): Promise<any> => {
+      const [[result]] = await (
+        await mysqlConnection
+      ).query<RowDataPacket[]>(
+        `SELECT * FROM VerificationToken WHERE identifier = ? AND token = ?`,
+        [params.identifier, params.token]
+      )
+
+      return result ?? null
     },
   },
 }

--- a/packages/mysql2/tests/index.test.ts
+++ b/packages/mysql2/tests/index.test.ts
@@ -1,0 +1,83 @@
+import type { RowDataPacket } from "mysql2/promise"
+import type { TestOptions } from "../../../basic-tests"
+import type { AdapterOptions } from "../src/types"
+import { runBasicTests } from "../../../basic-tests"
+import * as mysql from "mysql2/promise"
+import MySqlAdapter from "../src"
+
+const mysqlConnection = mysql.createConnection({
+  host: "localhost",
+  user: "root",
+  password: "test",
+  database: "nextauth-test",
+})
+
+const adapterOptions: AdapterOptions = !process.env.CUSTOM_MODEL
+  ? {}
+  : { extendUserModel: { role: "role", phone: "phone" } }
+const userSelectQuery = `id,name,email,email_verified AS emailVerified,image ${
+  !process.env.CUSTOM_MODEL ? "" : ",phone,role"
+}`
+
+const testOptions: TestOptions = {
+  adapter: MySqlAdapter(mysqlConnection, adapterOptions),
+  db: {
+    connect: async () => {
+      // cleanup DB
+      await (await mysqlConnection).execute("DELETE FROM Account")
+      await (await mysqlConnection).execute("DELETE FROM Session")
+      await (await mysqlConnection).execute("DELETE FROM User")
+    },
+    disconnect: async () => {
+      await (await mysqlConnection).end()
+    },
+    user: async (id): Promise<any> => {
+      const [result] = await (
+        await mysqlConnection
+      ).query<RowDataPacket[]>(
+        `SELECT ${userSelectQuery} FROM User WHERE id = ?`,
+        [id]
+      )
+      return result?.[0] ?? null
+    },
+    session: async (sessionToken: string): Promise<any> => {
+      const [result] = await (
+        await mysqlConnection
+      ).query<RowDataPacket[]>(
+        `SELECT id, expires, sessionToken, userId FROM Session WHERE sessionToken = ?`,
+        [sessionToken]
+      )
+      return result?.[0] ?? null
+    },
+    account: async (providerAccountId: {
+      provider: string
+      providerAccountId: string
+    }): Promise<any> => {
+      const [[result]] = await (
+        await mysqlConnection
+      ).query<RowDataPacket[]>(
+        `SELECT * FROM Account WHERE provider = ? AND providerAccountId = ?`,
+        [providerAccountId.provider, providerAccountId.providerAccountId]
+      )
+
+      if (!result) {
+        return null
+      }
+
+      // remove null values
+      const account: Record<string, any> = {}
+      for (const [key, value] of Object.entries(result)) {
+        if (value) {
+          account[key] = value
+        }
+      }
+
+      return account
+    },
+    verificationToken: (params) => {
+      return {}
+    },
+  },
+}
+
+runBasicTests(testOptions)

--- a/packages/mysql2/tests/seed-custom.sql
+++ b/packages/mysql2/tests/seed-custom.sql
@@ -76,6 +76,8 @@ CREATE TABLE `User` (
   `email` varchar(255) DEFAULT NULL,
   `email_verified` datetime(6) DEFAULT NULL,
   `image` varchar(255) DEFAULT NULL,
+  `role` varchar(45) DEFAULT NULL,
+  `phone` varchar(45) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `User_email` (`email`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/packages/mysql2/tests/seed.sql
+++ b/packages/mysql2/tests/seed.sql
@@ -1,0 +1,95 @@
+-- MySQL dump 10.13  Distrib 8.0.25, for macos11 (x86_64)
+--
+-- Host: 127.0.0.1    Database: nextauth-test
+-- ------------------------------------------------------
+-- Server version	8.0.27
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!50503 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `Account`
+--
+
+DROP TABLE IF EXISTS `Account`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `Account` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `type` varchar(255) NOT NULL,
+  `provider` varchar(255) NOT NULL,
+  `providerAccountId` varchar(255) NOT NULL,
+  `refresh_token` varchar(255) DEFAULT NULL,
+  `access_token` varchar(255) DEFAULT NULL,
+  `expires_at` int unsigned DEFAULT NULL,
+  `token_type` varchar(255) DEFAULT NULL,
+  `scope` varchar(255) DEFAULT NULL,
+  `id_token` varchar(255) DEFAULT NULL,
+  `userId` varchar(255) NOT NULL,
+  `oauth_token_secret` varchar(255) DEFAULT NULL,
+  `oauth_token` varchar(255) DEFAULT NULL,
+  `session_state` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `id` (`id`),
+  KEY `User_id_idx` (`userId`),
+  CONSTRAINT `Account_User_id` FOREIGN KEY (`userId`) REFERENCES `User` (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=13 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `Session`
+--
+
+DROP TABLE IF EXISTS `Session`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `Session` (
+  `id` varchar(255) NOT NULL,
+  `expires` datetime(6) NOT NULL,
+  `sessionToken` varchar(255) NOT NULL,
+  `userId` varchar(255) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `User_id_idx` (`userId`),
+  KEY `Session_sessionToken` (`sessionToken`),
+  CONSTRAINT `Session_User_id` FOREIGN KEY (`userId`) REFERENCES `User` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `User`
+--
+
+DROP TABLE IF EXISTS `User`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `User` (
+  `id` varchar(255) NOT NULL,
+  `name` varchar(255) DEFAULT NULL,
+  `email` varchar(255) DEFAULT NULL,
+  `email_verified` datetime(6) DEFAULT NULL,
+  `image` varchar(255) DEFAULT NULL,
+  `role` varchar(45) DEFAULT NULL,
+  `phone` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `User_email` (`email`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2021-12-19 18:18:22

--- a/packages/mysql2/tsconfig.json
+++ b/packages/mysql2/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "exclude": ["tests", "dist"]
+}


### PR DESCRIPTION
## Reasoning 💡

This PR introduces a new adapter for projects that use [mysql2](https://www.npmjs.com/package/mysql2) for MySQL databases. I know this is kind of a self-build ORM, however some smaller projects might appreciate to use a more lightweight MySQL driver than a full ORM framework.

Your feedback is welcome. 

For local testing please have a look into `packages/mysql2/tests`:

* use `docker-compose up` to start a MySQL docker instance
* use `mysql -hlocalhost --protocol=TCP -u root -p nextauth-test < seed.sql` to seed the database structure, or `seed-custom.sql` for the extended user model tests

## Checklist 🧢

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

