### PR TITLE
fix(dynamo): Ensure expires attribute is stored as a UNIX timestamp

### DIFF
--- a/packages/dynamodb/tests/format.test.ts
+++ b/packages/dynamodb/tests/format.test.ts
@@ -1,0 +1,95 @@
+import { format } from "../src/utils"
+
+describe("dynamodb utils.format", () => {
+  it("format.to() preserves non-Date non-expires properties", () => {
+    expect(
+      format.to({
+        pk: "test-pk",
+        email: "test@example.com",
+      })
+    ).toEqual({
+      pk: "test-pk",
+      email: "test@example.com",
+    })
+  })
+
+  it("format.to() converts non-expires Date properties to ISO strings", () => {
+    const date = new Date()
+    expect(
+      format.to({
+        dateProp: date,
+      })
+    ).toEqual({
+      dateProp: date.toISOString(),
+    })
+  })
+
+  it("format.to() converts expires property to a UNIX timestamp", () => {
+    // DynamoDB requires that the property used for TTL is a UNIX timestamp.
+    const date = new Date()
+    const timestamp = date.getTime() / 1000
+    expect(
+      format.to({
+        expires: date,
+      })
+    ).toEqual({
+      expires: timestamp,
+    })
+  })
+
+  it("format.from() preserves non-special attributes", () => {
+    expect(
+      format.from({
+        testAttr1: "test-value",
+        testAttr2: 5,
+      })
+    ).toEqual({
+      testAttr1: "test-value",
+      testAttr2: 5,
+    })
+  })
+
+  it("format.from() removes dynamodb key attributes", () => {
+    expect(
+      format.from({
+        pk: "test-pk",
+        sk: "test-sk",
+        GSI1PK: "test-GSI1PK",
+        GSI1SK: "test-GSI1SK",
+      })
+    ).toEqual({})
+  })
+
+  it("format.from() only removes type attribute from Session, VT, and User", () => {
+    expect(format.from({ type: "SESSION" })).toEqual({})
+    expect(format.from({ type: "VT" })).toEqual({})
+    expect(format.from({ type: "USER" })).toEqual({})
+    expect(format.from({ type: "ANYTHING" })).toEqual({ type: "ANYTHING" })
+    expect(format.from({ type: "ELSE" })).toEqual({ type: "ELSE" })
+  })
+
+  it("format.from() converts ISO strings to Date instances", () => {
+    const date = new Date()
+    expect(
+      format.from({
+        someDate: date.toISOString(),
+      })
+    ).toEqual({
+      someDate: date,
+    })
+  })
+
+  it("format.from() converts expires attribute from timestamp to Date instance", () => {
+    // AdapterSession["expires"] and VerificationToken["expires"] are both meant
+    // to be Date instances.
+    const date = new Date()
+    const timestamp = date.getTime() / 1000
+    expect(
+      format.from({
+        expires: timestamp,
+      })
+    ).toEqual({
+      expires: date,
+    })
+  })
+})

--- a/packages/dynamodb/tests/format.test.ts
+++ b/packages/dynamodb/tests/format.test.ts
@@ -92,4 +92,30 @@ describe("dynamodb utils.format", () => {
       expires: date,
     })
   })
+
+  it("format.from() converts expires attribute from ISO string to Date instance", () => {
+    // Due to a bug in an old version, some expires attributes were stored as
+    // ISO strings, so we need to handle those properly too.
+    const date = new Date()
+    expect(
+      format.from({
+        expires: date.toISOString(),
+      })
+    ).toEqual({
+      expires: date,
+    })
+  })
+
+  it("format.from(format.to()) preserves expires attribute", () => {
+    const date = new Date()
+    expect(
+      format.from(
+        format.to({
+          expires: date,
+        })
+      )
+    ).toEqual({
+      expires: date,
+    })
+  })
 })


### PR DESCRIPTION
## Reasoning 💡

Hi!  This is a small change compared to the number of words and tests I wrote!

This change applies to the DynamoDB adapter.

DynamoDB supports a "TTL" feature that automatically purges old items from the database if they are marked with a special attribute.  The [existing adapter docs](https://next-auth.js.org/adapters/dynamodb) suggest enabling this feature and setting it to use the `expires` attribute.  This is a reasonable choice, because Next Auth already uses the `expires` property on Sessions and VerificationTokens for basically the same purpose.

However, as clarified in the [AWS docs](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/time-to-live-ttl-before-you-start.html#time-to-live-ttl-before-you-start-formatting), the special TTL attribute must be stored as a UNIX timestamp in seconds.  I have fixed a bug in the DynamoDB adapter, which resulted in the `expires` attribute being stored as an ISO string, meaning that the TTL feature would not work for Next Auth Sessions and VerificationTokens.  Following this PR, the TTL feature should work, because now `expires` is stored as a numeric timestamp.

I added some unit tests for the code that converts objects to and from the format saved in DynamoDB.  Most of the tests were passing before this PR, but I thought it was worth adding them anyway.  All the tests pass on my machine with these changes.

The code before I edited it appeared to convert `expires` between a `number` and a `string`.  However, so far as I can tell, the `expires` property on `AdapterSession` and `VerificationToken` is a `Date`, so I think that code path was just being skipped entirely.  I can confirm that, in my database, the `expires` attribute is in fact being stored as an ISO string.  Paging @mathisobadia in case they know what the code was originally trying to do.

Thanks :)

## Checklist 🧢

- ~[ ] Documentation~
- [x] Tests
- [x] Ready to be merged

## Affected issues 🎟

This is related to #252, but that issue was closed (possibly incorrectly? I don't know if this worked in a previous version!).
