### PR TITLE
Prevent mongoDB updateUser from adding id twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ All adapter tests should also run against a local instance of the particular dat
 
 ## Publishing
 
-- [Lerna Independent Mode with Semver](https://samhogy.co.uk/2018/08/lerna-independent-mode-with-semver.html)
+- [Lerna Independent Mode with Semver](https://samhogy.co.uk/2018/08/lerna-independent-mode-with-semver)
 
 ## License
 

--- a/packages/mongodb/src/index.ts
+++ b/packages/mongodb/src/index.ts
@@ -111,9 +111,10 @@ export function MongoDBAdapter(
       return from<AdapterUser>(user)
     },
     async updateUser(data) {
+      const { id, ...rest } = data
       const { value: user } = await (
         await db
-      ).U.findOneAndUpdate({ _id: _id(data.id) }, { $set: data })
+      ).U.findOneAndUpdate({ _id: _id(id) }, { $set: rest })
       return from<AdapterUser>(user!)
     },
     async deleteUser(id) {


### PR DESCRIPTION
## Reasoning 💡

#### MongoDB Adapter
I noticed that when using the `updateUser` function, the `id` is basically copied and stored as an additional property. This seems unnecessary. This PR fixes this issue for the MongoDB adapter, I haven't checked if the same pattern exists within other adapters. In any case, it is not a big issue, but may save some bytes.

<img width="382" alt="Screen_Shot_2022-02-23_at_22_01_10" src="https://user-images.githubusercontent.com/1888817/155410088-8ee96ca6-1561-4398-8d88-ef8d9304f38f.png">


## Checklist 🧢

~~- [ ] Documentation~~
~~- [ ] Tests~~
- [x] Ready to be merged

## Affected issues 🎟

Might fix https://github.com/nextauthjs/next-auth/issues/4030
